### PR TITLE
feat: v0.2.0 신규 스킬 3개 추가 (harness-verify·review·abort)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sr-harness",
   "description": "karpathy-guidelines와 issue-driven development가 구조적으로 통합된 커스텀 개발 워크플로우 하네스",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": {
     "name": "SeokRae",
     "email": "kslbsh@gmail.com"
@@ -15,6 +15,9 @@
     "./skills/harness-issue",
     "./skills/harness-execute",
     "./skills/harness-finish",
-    "./skills/harness-debug"
+    "./skills/harness-debug",
+    "./skills/harness-verify",
+    "./skills/harness-review",
+    "./skills/harness-abort"
   ]
 }

--- a/skills/harness-abort/SKILL.md
+++ b/skills/harness-abort/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: harness-abort
+description: 작업 중단 및 브랜치 정리 스킬. "그만할게", "방향 바꿀게", "이 작업 취소", "브랜치 정리" 시 사용. session-plan Deviations 기록 + 브랜치 삭제 여부 확인. 어느 단계에서든 진입 가능.
+---
+
+# harness-abort
+
+작업을 중단할 때 흔적을 정리한다.
+**정리하지 않으면 다음 세션에서 좀비 브랜치와 stale session-plan이 남는다.**
+
+## 중단 유형
+
+| 유형 | 설명 | 처리 방식 |
+|------|------|----------|
+| **방향 전환** | 더 나은 접근법 발견, 다음 세션에서 재시도 | session-plan 유지, 브랜치 보존 |
+| **완전 폐기** | 이 작업 자체를 하지 않기로 결정 | session-plan 삭제, 브랜치 삭제 |
+| **일시 중단** | 지금은 못 하지만 나중에 재개 | session-plan 유지, 브랜치 보존 |
+
+## 실행 순서
+
+### 1. 중단 이유 기록
+`.claude/session-plan.md`의 Deviations 섹션에 기록한다:
+```markdown
+## Deviations
+
+- [중단] {날짜}: {이유} → {유형: 방향전환/폐기/일시중단}
+```
+
+### 2. 미완료 변경사항 처리
+```bash
+git status
+```
+
+- 커밋할 가치가 있는 변경 → `git stash` 또는 WIP 커밋
+- 버릴 변경 → `git checkout -- .`
+
+### 3. 브랜치 삭제 여부 확인
+사용자에게 선택을 묻는다:
+
+```
+현재 브랜치: feature/{N}-{description}
+원격 브랜치: origin/feature/{N}-{description}
+
+브랜치를 삭제할까요?
+A. 로컬 + 원격 모두 삭제
+B. 로컬만 삭제 (원격 보존)
+C. 보존 (나중에 재개)
+```
+
+A 선택 시:
+```bash
+git checkout main
+git branch -d feature/{N}-{description}
+git push origin --delete feature/{N}-{description}
+```
+
+### 4. Issue 상태 업데이트
+```bash
+# 완전 폐기인 경우 Issue close
+gh issue close {N} --comment "작업 중단: {이유}"
+
+# 방향 전환 / 일시 중단인 경우 코멘트만
+gh issue comment {N} --body "일시 중단: {이유}. 추후 재개 예정."
+```
+
+### 5. 완료 보고
+```
+[harness-abort 완료]
+중단 유형: {유형}
+기록 위치: session-plan.md Deviations
+브랜치: {삭제됨 / 보존됨}
+Issue #{N}: {closed / commented}
+```
+
+## 금지 사항
+
+- 이유 기록 없이 브랜치 삭제 금지
+- session-plan.md를 확인하지 않고 삭제 금지 (미완료 항목 확인 필수)
+- force push로 브랜치 내용 덮어쓰기 금지

--- a/skills/harness-execute/SKILL.md
+++ b/skills/harness-execute/SKILL.md
@@ -53,7 +53,7 @@ git commit -m "{type}: {설명} (#N)"
 
 ## 완료 조건
 
-harness-plan의 모든 단계 verify 통과 → `harness-finish` 호출
+harness-plan의 모든 단계 verify 통과 → `harness-verify` 호출 (통합 검증 후 harness-finish)
 
 ## 예외 상황
 

--- a/skills/harness-review/SKILL.md
+++ b/skills/harness-review/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: harness-review
+description: PR 리뷰 피드백 수신 및 반영 스킬. "리뷰 달렸어", "코멘트 반영해줘", "PR 피드백" 시 사용. 피드백을 반영/무시/논의로 분류하고 harness-execute 재진입. force push 없이 일반 push로 마무리.
+---
+
+# harness-review
+
+PR 리뷰 피드백은 새로운 작업 사이클의 시작이다.
+**피드백을 하나씩 확인하고, 반영 여부를 결정한 후 실행한다.**
+
+## 피드백 처리 흐름
+
+### 1. 피드백 분류
+리뷰어 코멘트를 세 종류로 분류한다:
+
+| 분류 | 기준 | 처리 |
+|------|------|------|
+| **반영** | 코드 변경이 필요한 지적 | session-plan에 step 추가 |
+| **무시** | 스타일 의견, 선호 차이 | 이유를 코멘트로 달고 넘어감 |
+| **논의** | 방향이 불명확한 것 | 리뷰어와 답글로 확인 후 결정 |
+
+분류 결과를 사용자에게 보여주고 확인받는다:
+```
+[피드백 분류 결과]
+반영 (N건): ...
+무시 (N건): ...
+논의 필요 (N건): ...
+
+계속 진행할까요?
+```
+
+### 2. session-plan.md 업데이트
+반영 항목을 plan의 새 step으로 추가한다:
+```yaml
+# session-plan.md에 추가
+- [ ] review: {반영 항목 설명} → verify: {확인 방법}
+```
+
+### 3. harness-execute 재진입
+session-plan의 새 step을 하나씩 실행한다.
+기존 코드를 수정하므로 karpathy §3 Surgical Changes를 반드시 적용한다.
+
+### 4. 완료 후 push
+```bash
+git add {변경 파일}
+git commit -m "fix: 리뷰 반영 — {반영 항목 요약} (#N)"
+git push origin feature/{N}-{description}
+```
+
+**force push 금지** — 일반 push로 PR 업데이트. 히스토리를 재작성하지 않는다.
+
+### 5. 리뷰 재요청
+```bash
+gh pr review {PR-number} --request-review {리뷰어}
+# 또는 PR 코멘트로 re-review 요청
+```
+
+## 무시 처리 방법
+
+무시하는 코멘트는 PR에 이유를 명시한다:
+```
+"이 부분은 [이유]로 현재 방식을 유지합니다."
+```
+설명 없는 무시는 하지 않는다.
+
+## 금지 사항
+
+- 피드백 분류 없이 바로 코드 수정 금지
+- force push / rebase로 히스토리 재작성 금지
+- 논의 미완료 항목을 임의로 반영 또는 무시 금지

--- a/skills/harness-verify/SKILL.md
+++ b/skills/harness-verify/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: harness-verify
+description: 구현 완료 후 PR 생성 전 통합 검증 스킬. harness-execute 모든 step verify 통과 후 자동 실행. 빌드·테스트·변경파일 전수 확인. 통과 시 harness-finish, 실패 시 harness-execute 재진입.
+---
+
+# harness-verify
+
+"완료됐다고 생각하는 것"과 "실제로 완료된 것"을 구분한다.
+**harness-finish를 호출하기 전에 반드시 이 스킬을 먼저 통과한다.**
+
+## 검증 체크리스트
+
+### 1. 미커밋 변경사항 없는지
+```bash
+git status
+```
+→ `nothing to commit` 이어야 통과. 아니면 커밋 또는 stash 후 재확인.
+
+### 2. 변경 파일 목록 확인
+```bash
+git diff origin/main --name-only
+```
+→ 목록을 사용자에게 보여준다. 의도하지 않은 파일이 있으면 멈추고 확인한다.
+
+### 3. 테스트 실행
+테스트 명령어는 다음 순서로 결정:
+1. `.claude/session-plan.md`의 `test-command` 필드
+2. 프로젝트 루트의 `./gradlew test` / `npm test` / `pytest`
+3. 모두 없으면 → 사용자에게 확인
+
+```bash
+{테스트 명령어 실행}
+```
+
+### 4. 검증 결과 보고
+```
+[harness-verify 결과]
+✅ 미커밋 변경사항 없음
+✅ 변경 파일: {N}개 (목록 표시)
+✅ 테스트: {명령어} → {통과/실패}
+```
+
+## 결과에 따른 전환
+
+| 결과 | 다음 단계 |
+|------|----------|
+| 모든 항목 통과 | `harness-finish` 호출 |
+| 테스트 실패 | `harness-debug` 전환 후 `harness-execute` 재진입 |
+| 의도치 않은 파일 변경 | 사용자 확인 후 수정 → 재검증 |
+| 미커밋 변경 있음 | 커밋 처리 후 재검증 |
+
+## 금지 사항
+
+- 테스트 실패 상태에서 harness-finish 진행 금지
+- 변경 파일 목록 확인 없이 harness-finish 진행 금지


### PR DESCRIPTION
## 변경 내용

LIFECYCLE.md의 Critical Gap 3개를 해소하는 신규 스킬.

| 스킬 | 역할 | 해소 Gap |
|------|------|----------|
| `harness-verify` | 통합 검증 (빌드+테스트+변경파일) | G2: 검증 단계 없음 |
| `harness-review` | PR 리뷰 피드백 분류·반영·재진입 | G1: 코드 리뷰 단계 없음 |
| `harness-abort` | 작업 중단/폐기/일시중단 경로 | G3: 중단 경로 없음 |

추가 변경:
- `harness-execute` 완료 조건: `harness-finish` → `harness-verify` 호출로 변경
- `plugin.json` v0.1.0 → v0.2.0, 3개 스킬 경로 등록

## 테스트

- [ ] harness-verify SKILL.md 검증 체크리스트 4단계 확인
- [ ] harness-review SKILL.md 피드백 분류 (반영/무시/논의) 확인
- [ ] harness-abort SKILL.md 중단 유형 3가지 + 브랜치 삭제 옵션 A/B/C 확인
- [ ] plugin.json 버전 0.2.0, 10개 스킬 등록 확인

Closes #5
Closes #6
Closes #7