### PR TITLE
feat: Worktree 격리 단계 추가 (P0 + P1)

### DIFF
--- a/skills/harness-execute/SKILL.md
+++ b/skills/harness-execute/SKILL.md
@@ -8,6 +8,16 @@ description: 구현 계획을 실행하는 스킬. "구현해줘", "만들어줘
 구현 시작 전 karpathy 체크포인트를 통과해야 한다.
 단계별로 실행하고, 각 단계가 끝나면 verify 후 다음으로 넘어간다.
 
+## 전제 조건 (Worktree 확인)
+
+현재 작업 디렉토리가 worktree(`.claude/worktrees/{description}`) 안인지 확인한다.
+- 맞으면 → 진행
+- 아니면 → `harness-issue`로 돌아가서 worktree 생성
+
+```bash
+git worktree list | grep "$(pwd)"
+```
+
 ## 시작 전 체크포인트 (karpathy §1 Think Before Coding)
 
 다음을 확인하고 넘어간다:
@@ -48,6 +58,8 @@ description: 구현 계획을 실행하는 스킬. "구현해줘", "만들어줘
 git add {관련 파일만}
 git commit -m "{type}: {설명} (#N)"
 ```
+
+**`git add .` 사용 금지** — 관련 파일만 개별 지정한다.
 
 **커밋 단위**: `harness-plan`의 단계 하나에서 verify를 통과한 변경이 커밋 하나다.
 - verify를 통과하기 전에 커밋하지 않는다

--- a/skills/harness-finish/SKILL.md
+++ b/skills/harness-finish/SKILL.md
@@ -18,12 +18,7 @@ git status   # 미커밋 변경사항 없는지
 테스트 명령어는 다음 순서로 결정한다:
 1. `.claude/session-plan.md`의 `test-command` 필드가 있으면 → 그 명령어 실행
 2. 없으면 → 프로젝트 루트에서 `./gradlew test` / `npm test` / `pytest` 순으로 시도
-3. 어느 것도 없으면 → 사용자에게 테스트 명령어 확인 후 실행
-
-```yaml
-# session-plan.md 예시
-test-command: ./gradlew integrationTest
-```
+3. 어느 것도 없으면 → 스킵 (vault 등 테스트 없는 프로젝트)
 
 ### 2. Push
 ```bash
@@ -47,10 +42,17 @@ Closes #{N}"
 
 **PR body `Closes #N` 필수** — 커밋 메시지의 `(#N)`은 Issue를 자동 close하지 않음.
 
-### 4. 완료 보고
+### 4. Worktree 정리
+```bash
+cd {프로젝트 루트}              # vault root로 복귀
+git worktree remove .claude/worktrees/{description}
+```
+
+### 5. 완료 보고
 ```
 ✅ PR 생성: #{PR-number}
 ✅ Closes #{issue-number}
+✅ Worktree 정리: .claude/worktrees/{description} 제거
 브랜치: feature/{N}-{description}
 ```
 

--- a/skills/harness-issue/SKILL.md
+++ b/skills/harness-issue/SKILL.md
@@ -31,11 +31,25 @@ git checkout -b feature/{issue-number}-{short-description}
 - 다른 feature 브랜치에서 분기 (체인 브랜치 금지)
 - 한 브랜치에 여러 Issue 혼재
 
-### 3. 확인 출력
+### 3. Worktree 생성 (격리 의무)
+```bash
+git checkout main
+git worktree add .claude/worktrees/{short-description} feature/{issue-number}-{short-description}
+```
+
+이후 모든 파일 작업은 worktree 안에서 수행한다.
+
+**컨벤션**:
+- 위치: `.claude/worktrees/` (프로젝트 `.gitignore`에 포함 확인)
+- 이름: 브랜치의 `{short-description}` 부분 그대로 사용
+- `.gitignore`에 `.claude/worktrees/` 없으면 추가 후 커밋
+
+### 4. 확인 출력
 ```
 ✅ Issue #N 생성: {제목}
 ✅ 브랜치 생성: feature/{N}-{description}
-✅ 현재 위치: feature/{N}-{description}
+✅ Worktree 생성: .claude/worktrees/{description}
+✅ 현재 위치: .claude/worktrees/{description}
 
 다음 단계: harness-execute
 ```

--- a/skills/harness-start/SKILL.md
+++ b/skills/harness-start/SKILL.md
@@ -13,7 +13,14 @@ description: sr-harness 세션 진입점. 모든 대화 시작 시 반드시 먼
    - 있으면: 목표와 미완료 항목 로드 → 사용자에게 한 줄로 상태 보고
    - 없으면: 작업 시작 전에 생성 (목표 + scope + tasks 포함)
 
-2. 아래 라우팅 표로 적절한 스킬 호출
+2. 활성 worktree 감지
+   ```bash
+   git worktree list
+   ```
+   - `.claude/worktrees/`에 활성 worktree가 있으면 → 해당 작업 재개 안내
+   - 없으면 → 새 작업 시작
+
+3. 아래 라우팅 표로 적절한 스킬 호출
 
 ## 라우팅 표
 
@@ -44,3 +51,8 @@ description: sr-harness 세션 진입점. 모든 대화 시작 시 반드시 먼
 - **단순성**: 더 단순한 방법이 있으면 → 먼저 제안
 - **성공 기준**: 완료 조건이 없으면 → 정의 후 시작
 
+## superpowers와의 관계
+
+이 플러그인이 설치된 경우, superpowers 워크플로우 스킬 대신 harness-* 스킬을 우선 사용한다.
+superpowers의 유틸리티 스킬(dispatching-parallel-agents 등)은 그대로 사용 가능.
+워크트리 관리는 sr-harness가 자체 처리한다 (`harness-issue` Step 3, `harness-finish` Step 4).


### PR DESCRIPTION
## 변경 내용

Codex 리뷰 기반 P0/P1 개선. Worktree 격리가 스킬 레벨에서 강제됨.

### P0 (필수)
| 스킬 | 변경 |
|------|------|
| `harness-issue` | Step 3 추가: `.claude/worktrees/{desc}` 생성 + .gitignore 확인 |
| `harness-execute` | 전제 조건 섹션: worktree 안에서 실행 중인지 assert |
| `harness-execute` | `git add .` 사용 금지 명시 |
| `harness-finish` | Step 4 추가: worktree 정리 + vault root 복귀 |
| `harness-finish` | hardcoded `./gradlew integrationTest` 제거 |

### P1 (부가)
| 스킬 | 변경 |
|------|------|
| `harness-start` | 세션 시작 시 활성 worktree 감지 (재개 안내) |
| `harness-start` | superpowers 관계 설명에서 worktree 자체 처리 명시 |

Closes #9