### PR TITLE
feat: harness-pause 스킬 추가

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,13 +1,19 @@
 {
   "name": "sr-harness",
   "description": "karpathy-guidelines와 issue-driven development가 구조적으로 통합된 커스텀 개발 워크플로우 하네스",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": {
     "name": "SeokRae",
     "email": "kslbsh@gmail.com"
   },
   "license": "MIT",
-  "keywords": ["harness", "workflow", "karpathy", "issue-driven", "tdd"],
+  "keywords": [
+    "harness",
+    "workflow",
+    "karpathy",
+    "issue-driven",
+    "tdd"
+  ],
   "skills": [
     "./skills/harness-start",
     "./skills/harness-brainstorm",
@@ -18,6 +24,7 @@
     "./skills/harness-debug",
     "./skills/harness-verify",
     "./skills/harness-review",
-    "./skills/harness-abort"
+    "./skills/harness-abort",
+    "./skills/harness-pause"
   ]
 }

--- a/skills/harness-pause/SKILL.md
+++ b/skills/harness-pause/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: harness-pause
+description: 세션 중단 및 다음 세션 인계 스킬. "세션 마무리해줘", "여기까지만", "다음 세션에서 이어서", "오늘은 여기까지", "잠깐 끊을게" 시 사용. session-plan.md를 최신화하여 harness-start가 다음 세션에서 자동으로 이어받을 수 있게 한다.
+---
+
+# harness-pause
+
+세션을 안전하게 중단하고, 다음 세션이 끊김 없이 이어갈 수 있도록 현재 상태를 저장한다.
+
+## 실행 순서
+
+### 1. 미커밋 변경사항 확인
+
+```bash
+git status
+```
+
+- 미커밋 변경사항이 있으면 → 커밋할지 사용자에게 확인
+- 커밋하려면 `harness-execute`의 커밋 단계로 안내
+- 커밋 안 해도 된다면 → 그대로 진행 (WIP 상태임을 session-plan에 기록)
+
+### 2. 활성 worktree 확인
+
+```bash
+git worktree list
+```
+
+활성 worktree가 있으면 브랜치명과 Issue 번호를 session-plan에 기록한다.
+
+### 3. session-plan.md 생성 또는 업데이트
+
+파일 위치: `{프로젝트 루트}/.claude/session-plan.md`
+
+**이미 있으면**: 완료된 항목을 `- [x]`로, 미완료 항목은 `- [ ]`로 업데이트.
+**없으면**: 아래 형식으로 새로 생성.
+
+```markdown
+---
+session: YYYY-MM-DD
+goal: {이번 세션에서 한 일 한 줄 요약}
+branch: feature/{N}-{description}   # 활성 worktree가 있을 때만
+issue: {N}                           # 활성 worktree가 있을 때만
+scope:
+  - {완료한 작업 항목}
+  - {남은 작업 항목}
+out-of-scope:
+  - {이번 세션에서 다루지 않기로 한 것}
+---
+
+## Tasks
+
+- [x] {완료된 항목}
+- [ ] {미완료 항목}
+
+## Deviations
+
+{범위 이탈 항목 — 새 세션 후보}
+```
+
+### 4. 인계 요약 출력
+
+사용자에게 다음 형식으로 보고한다:
+
+```
+⏸ 세션 중단
+
+✅ 완료: {완료된 항목 목록}
+⏳ 남은 작업: {미완료 항목 목록}
+📌 다음 세션 시작점: {다음에 해야 할 첫 번째 항목}
+
+session-plan.md 저장됨 → 다음 세션에서 harness-start가 자동으로 이어받습니다.
+```
+
+## 주의
+
+- worktree는 제거하지 않는다 — 다음 세션에서 harness-start가 감지해 재개 안내
+- session-plan.md는 프로젝트 루트 `.claude/` 아래에 저장 (vault는 `.claude/session-plan.md`)
+- 미완료 항목이 0개면 → harness-finish로 안내 (브랜치를 완전히 닫을 수 있는 상태)

--- a/skills/harness-start/SKILL.md
+++ b/skills/harness-start/SKILL.md
@@ -13,7 +13,14 @@ description: sr-harness 세션 진입점. 모든 대화 시작 시 반드시 먼
    - 있으면: 목표와 미완료 항목 로드 → 사용자에게 한 줄로 상태 보고
    - 없으면: 작업 시작 전에 생성 (목표 + scope + tasks 포함)
 
-2. 아래 라우팅 표로 적절한 스킬 호출
+2. 활성 worktree 감지
+   ```bash
+   git worktree list
+   ```
+   - `.claude/worktrees/`에 활성 worktree가 있으면 → 해당 작업 재개 안내
+   - 없으면 → 새 작업 시작
+
+3. 아래 라우팅 표로 적절한 스킬 호출
 
 ## 라우팅 표
 
@@ -25,6 +32,7 @@ description: sr-harness 세션 진입점. 모든 대화 시작 시 반드시 먼
 | 코드 작성, 기능 구현, PR 작업 | `harness-execute` |
 | 버그, 테스트 실패, 에러 | `harness-debug` |
 | 완료, PR 올리기, 브랜치 마무리 | `harness-finish` |
+| 세션 중단, 다음 세션에서 이어서, 여기까지만 | `harness-pause` |
 
 ### 의도 모호 시 질문 목록
 
@@ -44,3 +52,8 @@ description: sr-harness 세션 진입점. 모든 대화 시작 시 반드시 먼
 - **단순성**: 더 단순한 방법이 있으면 → 먼저 제안
 - **성공 기준**: 완료 조건이 없으면 → 정의 후 시작
 
+## superpowers와의 관계
+
+이 플러그인이 설치된 경우, superpowers 워크플로우 스킬 대신 harness-* 스킬을 우선 사용한다.
+superpowers의 유틸리티 스킬(dispatching-parallel-agents 등)은 그대로 사용 가능.
+워크트리 관리는 sr-harness가 자체 처리한다 (`harness-issue` Step 3, `harness-finish` Step 4).


### PR DESCRIPTION
Closes #11

## 변경 사항
- skills/harness-pause/SKILL.md 신규 생성
- skills/harness-start/SKILL.md 라우팅 표에 harness-pause 항목 추가

## 동작
트리거: 세션 마무리해줘, 여기까지만, 다음 세션에서 이어서
1. 미커밋 변경사항 확인
2. 활성 worktree 상태 확인
3. session-plan.md 최신화 (완료/미완료 표시)
4. 인계 요약 출력