### PR TITLE
feat: harness-submit 스킬 추가 및 harness-finish 역할 재정의 (v0.4.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sr-harness",
   "description": "karpathy-guidelines와 issue-driven development가 구조적으로 통합된 커스텀 개발 워크플로우 하네스",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": {
     "name": "SeokRae",
     "email": "kslbsh@gmail.com"
@@ -20,6 +20,7 @@
     "./skills/harness-plan",
     "./skills/harness-issue",
     "./skills/harness-execute",
+    "./skills/harness-submit",
     "./skills/harness-finish",
     "./skills/harness-debug",
     "./skills/harness-verify",

--- a/README.md
+++ b/README.md
@@ -96,9 +96,20 @@ harness-start
       │    Diagnose before touching code
       │    Never retry the same failing approach twice
       │
+      ├─ harness-verify
+      │    Integration check before submitting
+      │    git status · changed files · test suite
+      │
+      ├─ harness-submit
+      │    push → PR with "Closes #N" in body
+      │    Stops here. User reviews the PR.
+      │
+      ├─ harness-review
+      │    Receive review feedback → back to execute
+      │
       └─ harness-finish
-           push → PR with "Closes #N" in body
-           No alternatives. Always a PR.
+           Merge + delete branch + pull main
+           The work is truly done.
 ```
 
 ---
@@ -112,8 +123,13 @@ harness-start
 | `harness-plan` | Planning with step → verify format |
 | `harness-issue` | GitHub Issue + branch creation |
 | `harness-execute` | Implementation with Karpathy checkpoints |
-| `harness-finish` | push + PR (Closes #N) |
 | `harness-debug` | Diagnose-first debugging |
+| `harness-verify` | Integration check before PR |
+| `harness-submit` | push + PR (Closes #N) · stops for user review |
+| `harness-review` | Receive review feedback → back to execute |
+| `harness-finish` | Merge + delete branch + pull main |
+| `harness-abort` | Cancel work · clean up branch |
+| `harness-pause` | Suspend session · hand off to next session |
 
 ---
 

--- a/docs/LIFECYCLE.md
+++ b/docs/LIFECYCLE.md
@@ -120,10 +120,11 @@
 | EXECUTE | VERIFY | 모든 step verify 통과 | harness-execute → **harness-verify** *(v0.2)* |
 | VERIFY | REVIEW | 통합 검증 통과 | harness-verify → **harness-review** *(v0.2)* |
 | VERIFY | EXECUTE | 검증 실패 → 추가 수정 필요 | harness-verify → harness-execute |
-| REVIEW | FINISH | solo 진행 또는 approve | **harness-review** → harness-finish |
-| REVIEW | EXECUTE | 리뷰 피드백 수신 → 반영 | **harness-review** → harness-execute |
-| FINISH | CLEANUP | PR 생성 완료 | harness-finish (session-plan 정리) |
-| ANY | ABORT | 방향 전환 / 폐기 결정 | **harness-abort** *(v0.2)* |
+| REVIEW | SUBMIT | solo 진행 또는 approve | harness-review → harness-submit |
+| REVIEW | EXECUTE | 리뷰 피드백 수신 → 반영 | harness-review → harness-execute |
+| SUBMIT | FINISH | 사용자가 PR 확인 후 머지 요청 | harness-finish |
+| FINISH | DONE | 머지 + 브랜치 정리 + main pull 완료 | harness-finish |
+| ANY | ABORT | 방향 전환 / 폐기 결정 | harness-abort |
 
 > **볼드** 표시: v0.2에서 신규 추가 예정 스킬
 

--- a/skills/harness-execute/SKILL.md
+++ b/skills/harness-execute/SKILL.md
@@ -69,7 +69,7 @@ git commit -m "{type}: {설명} (#N)"
 
 ## 완료 조건
 
-harness-plan의 모든 단계 verify 통과 → `harness-verify` 호출 (통합 검증 후 harness-finish)
+harness-plan의 모든 단계 verify 통과 → `harness-verify` 호출 (통합 검증 후 harness-submit)
 
 ## 예외 상황
 

--- a/skills/harness-finish/SKILL.md
+++ b/skills/harness-finish/SKILL.md
@@ -1,63 +1,52 @@
 ---
 name: harness-finish
-description: 브랜치 마무리 및 PR 생성 스킬. "완료", "PR 올려줘", "마무리", "push해줘" 시 사용. 항상 push + PR(Closes #N)로 마무리. 다른 선택지(로컬 머지, 브랜치 폐기 등) 없음.
+description: PR 머지 및 브랜치 정리 스킬. "머지해줘", "마무리해줘", "브랜치 정리", "완료 처리" 시 사용. harness-submit으로 PR 생성 후 사용자 확인이 끝나면 실행. 머지 + 브랜치 삭제 + main pull까지 처리.
 ---
 
 # harness-finish
 
-구현이 완료되면 반드시 push + PR로 마무리한다.
-**다른 선택지는 없다.** 로컬 머지, 브랜치 폐기는 이 프로젝트에서 선택지가 아니다.
+사용자가 PR을 확인하고 승인했다. 이제 진짜 마무리다.
+머지 → 브랜치 삭제 → main 동기화 순서로 처리한다.
 
 ## 실행 순서
 
-### 1. 최종 확인
+### 1. PR 상태 확인
 ```bash
-git status   # 미커밋 변경사항 없는지
+gh pr view {PR-number}
+```
+→ 리뷰 코멘트나 미해결 이슈가 있으면 사용자에게 확인 후 진행.
+
+### 2. 머지
+```bash
+gh pr merge {PR-number} --squash --delete-branch
 ```
 
-테스트 명령어는 다음 순서로 결정한다:
-1. `.claude/session-plan.md`의 `test-command` 필드가 있으면 → 그 명령어 실행
-2. 없으면 → 프로젝트 루트에서 `./gradlew test` / `npm test` / `pytest` 순으로 시도
-3. 어느 것도 없으면 → 스킵 (vault 등 테스트 없는 프로젝트)
+머지 전략 선택 기준:
+- `--squash`: 기본값. 단일 커밋으로 정리되어 main 히스토리가 깔끔함
+- `--merge`: step별 커밋을 main에 그대로 남겨야 할 때
+- `--rebase`: 리니어 히스토리를 유지하면서 각 커밋을 보존할 때
 
-### 2. Push
+### 3. main 동기화
 ```bash
-git push origin feature/{N}-{description}
+git checkout main
+git pull origin main
 ```
 
-### 3. PR 생성
+### 4. Worktree 정리 (worktree 사용 시)
 ```bash
-gh pr create \
-  --title "{type}: {설명}" \
-  --body "## 변경 내용
-
-{변경 내용 요약}
-
-## 테스트
-
-- [ ] 통합 테스트 통과
-
-Closes #{N}"
-```
-
-**PR body `Closes #N` 필수** — 커밋 메시지의 `(#N)`은 Issue를 자동 close하지 않음.
-
-### 4. Worktree 정리
-```bash
-cd {프로젝트 루트}              # vault root로 복귀
 git worktree remove .claude/worktrees/{description}
 ```
 
 ### 5. 완료 보고
 ```
-✅ PR 생성: #{PR-number}
-✅ Closes #{issue-number}
-✅ Worktree 정리: .claude/worktrees/{description} 제거
-브랜치: feature/{N}-{description}
+✅ PR #{PR-number} 머지 완료
+✅ Issue #{issue-number} close
+✅ 브랜치 삭제: feature/{N}-{description}
+✅ main 동기화 완료
 ```
 
 ## session-plan.md 정리
 
-PR 생성 후:
-- 완료 → 파일 삭제 또는 아카이브
-- 미완료 항목 있으면 → 파일 유지 (다음 세션에서 이어서 사용)
+머지 완료 후:
+- 완료 → 파일 삭제
+- 다음 세션 작업이 남아 있으면 → 새 session-plan.md 작성 권장

--- a/skills/harness-start/SKILL.md
+++ b/skills/harness-start/SKILL.md
@@ -31,7 +31,8 @@ description: sr-harness 세션 진입점. 모든 대화 시작 시 반드시 먼
 | Issue 생성, 브랜치 생성 | `harness-issue` |
 | 코드 작성, 기능 구현, PR 작업 | `harness-execute` |
 | 버그, 테스트 실패, 에러 | `harness-debug` |
-| 완료, PR 올리기, 브랜치 마무리 | `harness-finish` |
+| PR 올리기, push, 리뷰 요청 | `harness-submit` |
+| 머지, 마무리, 브랜치 정리 | `harness-finish` |
 | 세션 중단, 다음 세션에서 이어서, 여기까지만 | `harness-pause` |
 
 ### 의도 모호 시 질문 목록
@@ -57,3 +58,11 @@ description: sr-harness 세션 진입점. 모든 대화 시작 시 반드시 먼
 이 플러그인이 설치된 경우, superpowers 워크플로우 스킬 대신 harness-* 스킬을 우선 사용한다.
 superpowers의 유틸리티 스킬(dispatching-parallel-agents 등)은 그대로 사용 가능.
 워크트리 관리는 sr-harness가 자체 처리한다 (`harness-issue` Step 3, `harness-finish` Step 4).
+
+## 워크플로우 전체 흐름
+
+```
+brainstorm → plan → issue → execute → verify → submit → [사용자 확인] → finish
+                               ↑ debug ↓
+                           review (리뷰 피드백 반영 시)
+```

--- a/skills/harness-submit/SKILL.md
+++ b/skills/harness-submit/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: harness-submit
+description: 구현 완료 후 push + PR 생성 스킬. "PR 올려줘", "push해줘", "submit", "리뷰 요청" 시 사용. 항상 push + PR(Closes #N)로 제출. 사용자가 PR을 눈으로 확인한 뒤 harness-finish로 머지.
+---
+
+# harness-submit
+
+검증이 완료된 브랜치를 리뷰에 제출한다.
+push + PR 생성이 이 스킬의 끝이다. **머지는 사용자가 확인 후 `harness-finish`에서 처리한다.**
+
+## 실행 순서
+
+### 1. 최종 확인
+```bash
+git status   # 미커밋 변경사항 없는지
+```
+
+테스트 명령어는 다음 순서로 결정한다:
+1. `.claude/session-plan.md`의 `test-command` 필드가 있으면 → 그 명령어 실행
+2. 없으면 → 프로젝트 루트에서 `./gradlew test` / `npm test` / `pytest` 순으로 시도
+3. 어느 것도 없으면 → 사용자에게 테스트 명령어 확인 후 실행
+
+```yaml
+# session-plan.md 예시
+test-command: ./gradlew integrationTest
+```
+
+### 2. Push
+```bash
+git push origin feature/{N}-{description}
+```
+
+### 3. PR 생성
+```bash
+gh pr create \
+  --title "{type}: {설명}" \
+  --body "## 변경 내용
+
+{변경 내용 요약}
+
+## 테스트
+
+- [ ] 통합 테스트 통과
+
+Closes #{N}"
+```
+
+**PR body `Closes #N` 필수** — 커밋 메시지의 `(#N)`은 Issue를 자동 close하지 않음.
+
+### 4. 제출 보고
+```
+✅ PR 생성: #{PR-number}
+✅ Closes #{issue-number}
+브랜치: feature/{N}-{description}
+
+PR을 확인하고 머지할 준비가 되면 harness-finish를 실행하세요.
+```
+
+## session-plan.md 정리
+
+PR 생성 후:
+- 완료 → 파일 삭제 또는 아카이브
+- 미완료 항목 있으면 → 파일 유지 (다음 세션에서 이어서 사용)

--- a/skills/harness-verify/SKILL.md
+++ b/skills/harness-verify/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: harness-verify
-description: 구현 완료 후 PR 생성 전 통합 검증 스킬. harness-execute 모든 step verify 통과 후 자동 실행. 빌드·테스트·변경파일 전수 확인. 통과 시 harness-finish, 실패 시 harness-execute 재진입.
+description: 구현 완료 후 PR 생성 전 통합 검증 스킬. harness-execute 모든 step verify 통과 후 자동 실행. 빌드·테스트·변경파일 전수 확인. 통과 시 harness-submit, 실패 시 harness-execute 재진입.
 ---
 
 # harness-verify
 
 "완료됐다고 생각하는 것"과 "실제로 완료된 것"을 구분한다.
-**harness-finish를 호출하기 전에 반드시 이 스킬을 먼저 통과한다.**
+**harness-submit를 호출하기 전에 반드시 이 스킬을 먼저 통과한다.**
 
 ## 검증 체크리스트
 
@@ -44,12 +44,12 @@ git diff origin/main --name-only
 
 | 결과 | 다음 단계 |
 |------|----------|
-| 모든 항목 통과 | `harness-finish` 호출 |
+| 모든 항목 통과 | `harness-submit` 호출 |
 | 테스트 실패 | `harness-debug` 전환 후 `harness-execute` 재진입 |
 | 의도치 않은 파일 변경 | 사용자 확인 후 수정 → 재검증 |
 | 미커밋 변경 있음 | 커밋 처리 후 재검증 |
 
 ## 금지 사항
 
-- 테스트 실패 상태에서 harness-finish 진행 금지
-- 변경 파일 목록 확인 없이 harness-finish 진행 금지
+- 테스트 실패 상태에서 harness-submit 진행 금지
+- 변경 파일 목록 확인 없이 harness-submit 진행 금지


### PR DESCRIPTION
## 변경 내용

### 신규: `harness-submit`
push + PR 생성 전담. 사용자가 PR을 확인하는 구간을 명시적으로 분리.

### 변경: `harness-finish`
머지 + 브랜치 삭제 + main pull — 진짜 마무리 단계.

### 워크플로우
```
execute → verify → submit → [사용자 PR 확인] → finish
```

## 연관 업데이트
- `harness-start`: 라우팅 표 분리 + 전체 흐름도 추가
- `harness-execute`, `harness-verify`: finish → submit 참조 변경
- `LIFECYCLE.md`, `README.md`: v0.4 기준 최신화
- `plugin.json`: v0.4.0

Closes #16