### PR TITLE
feat: GitHub Actions Pages 배포 워크플로우 추가

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,30 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./docs
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 *.local
+.claude/worktrees/


### PR DESCRIPTION
## 변경 내용

- `.github/workflows/pages.yml` 신규 추가
  - `main` push 시 `docs/` 폴더를 GitHub Pages에 자동 배포
  - `workflow_dispatch`로 수동 실행도 가능
- `.gitignore`에 `.claude/worktrees/` 추가

## 확인 방법

1. PR 머지 후 GitHub Settings → Pages → Source를 **GitHub Actions** 로 변경
2. Actions 탭에서 워크플로우 실행 확인
3. https://seokrae.github.io/sr-harness/ 접속

Closes #20