### PR TITLE
fix: harness-ralph 안정성 개선 — 스크립트 분리 + session ID 버그 수정

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "karpathy-guidelines와 issue-driven development가 구조적으로 통합된 커스텀 개발 워크플로우 하네스",
-    "version": "0.7.0"
+    "version": "0.7.1"
   },
   "plugins": [
     {
       "name": "sr-harness",
       "source": "./",
       "description": "karpathy-guidelines와 issue-driven development가 구조적으로 통합된 커스텀 개발 워크플로우 하네스",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "author": {
         "name": "SeokRae",
         "email": "kslbsh@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sr-harness",
   "description": "karpathy-guidelines와 issue-driven development가 구조적으로 통합된 커스텀 개발 워크플로우 하네스",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "author": {
     "name": "SeokRae",
     "email": "kslbsh@gmail.com"

--- a/scripts/cleanup-ralph.sh
+++ b/scripts/cleanup-ralph.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# harness-ralph cleanup script
+# bypass 권한 복구 + Ralph 상태 파일 제거
+
+set -euo pipefail
+
+STATE_FILE=".claude/ralph-loop.local.md"
+SETTINGS_FILE=".claude/settings.local.json"
+SETTINGS_BACKUP="${SETTINGS_FILE}.ralph-backup"
+
+# ── bypass 권한 복구 ───────────────────────────────────────
+if [[ -f "$SETTINGS_BACKUP" ]]; then
+  mv "$SETTINGS_BACKUP" "$SETTINGS_FILE"
+  echo "🔒 settings.local.json 복구 완료 (백업에서 복원)"
+else
+  # 백업 없음 = ralph가 처음 생성한 파일 → 삭제
+  if [[ -f "$SETTINGS_FILE" ]]; then
+    rm -f "$SETTINGS_FILE"
+    echo "🔒 settings.local.json 제거 (ralph가 생성한 파일)"
+  fi
+fi
+
+# ── 상태 파일 제거 ─────────────────────────────────────────
+if [[ -f "$STATE_FILE" ]]; then
+  ITER=$(grep '^iteration:' "$STATE_FILE" | sed 's/iteration: *//' || echo "?")
+  rm -f "$STATE_FILE"
+  echo "🧹 Ralph 상태 파일 제거 (iteration: ${ITER})"
+else
+  echo "ℹ️  Ralph 상태 파일 없음 (이미 제거됨)"
+fi
+
+echo "✅ harness-ralph cleanup 완료"

--- a/scripts/setup-ralph.sh
+++ b/scripts/setup-ralph.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+# harness-ralph setup script
+# session-plan.md 기반으로 Ralph 상태 파일 + bypass 권한 설정
+
+set -euo pipefail
+
+PLAN_FILE=".claude/session-plan.md"
+STATE_FILE=".claude/ralph-loop.local.md"
+SETTINGS_FILE=".claude/settings.local.json"
+SETTINGS_BACKUP="${SETTINGS_FILE}.ralph-backup"
+
+# ── 전제 조건 확인 ─────────────────────────────────────────
+if [[ ! -f "$PLAN_FILE" ]]; then
+  echo "❌ .claude/session-plan.md 없음. plan 스킬로 먼저 계획을 작성하세요." >&2
+  exit 1
+fi
+
+WORKTREE_CHECK=$(git worktree list | grep "$(pwd)" | grep -v "bare" || true)
+if [[ -z "$WORKTREE_CHECK" ]]; then
+  echo "❌ worktree 밖에서 실행됨. .claude/worktrees/ 안으로 이동하세요." >&2
+  exit 1
+fi
+
+if [[ -f "$STATE_FILE" ]]; then
+  echo "⚠️  활성 Ralph 루프가 이미 존재합니다: $STATE_FILE" >&2
+  echo "   취소하려면: /cancel-ralph 또는 bash \"\${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-ralph.sh\"" >&2
+  exit 1
+fi
+
+# ── session-plan.md 파싱 ───────────────────────────────────
+GOAL=$(grep -m1 '^goal:' "$PLAN_FILE" | sed 's/^goal: *//' || echo "목표 미정의")
+ISSUE=$(grep -m1 '#[0-9]' "$PLAN_FILE" | grep -o '#[0-9]*' | head -1 || echo "#?")
+TEST_CMD=$(grep -m1 '^test-command:' "$PLAN_FILE" | sed 's/^test-command: *//' || echo "")
+
+# 미완료 Tasks 추출
+TASKS=$(grep '^\- \[ \]' "$PLAN_FILE" || echo "- [ ] (Tasks 항목 없음)")
+
+# max_iterations 결정
+TASK_COUNT=$(echo "$TASKS" | grep -c '^\- \[ \]' || echo 0)
+if [[ $TASK_COUNT -le 3 ]]; then
+  MAX_ITER=10
+elif [[ $TASK_COUNT -le 6 ]]; then
+  MAX_ITER=15
+else
+  MAX_ITER=20
+fi
+
+# 테스트 명령어 자동 감지
+if [[ -z "$TEST_CMD" ]]; then
+  if [[ -f "./gradlew" ]]; then
+    TEST_CMD="./gradlew test"
+  elif [[ -f "package.json" ]]; then
+    TEST_CMD="npm test"
+  elif [[ -f "pytest.ini" ]] || [[ -f "pyproject.toml" ]]; then
+    TEST_CMD="pytest"
+  else
+    TEST_CMD="(테스트 명령어 미확인 — 수동 실행 필요)"
+  fi
+fi
+
+# ── bypass 권한 설정 ───────────────────────────────────────
+mkdir -p .claude
+
+# 기존 파일 백업
+if [[ -f "$SETTINGS_FILE" ]]; then
+  cp "$SETTINGS_FILE" "$SETTINGS_BACKUP"
+  echo "📋 settings.local.json 백업: $SETTINGS_BACKUP"
+fi
+
+# bypass 권한 파일 생성
+cat > "$SETTINGS_FILE" <<'SETTINGS_EOF'
+{
+  "permissions": {
+    "allow": [
+      "Bash(*)",
+      "Read(*)",
+      "Edit(*)",
+      "Write(*)",
+      "Agent(*)",
+      "Skill(*)"
+    ]
+  }
+}
+SETTINGS_EOF
+
+echo "🔓 bypass 권한 설정 완료"
+
+# ── Ralph 상태 파일 생성 ────────────────────────────────────
+SESSION_ID="${CLAUDE_CODE_SESSION_ID:-}"
+STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# 상태 파일 헤더 작성
+cat > "$STATE_FILE" <<HEADER
+---
+active: true
+iteration: 1
+session_id: ${SESSION_ID}
+max_iterations: ${MAX_ITER}
+completion_promise: "READY_FOR_PR"
+started_at: "${STARTED_AT}"
+---
+
+HEADER
+
+# Ralph 프롬프트 본문 추가 (변수 확장 없는 heredoc)
+cat >> "$STATE_FILE" <<'PROMPT_EOF'
+sr-harness execute + verify 자동화 루프
+
+## 현재 컨텍스트
+PROMPT_EOF
+
+# 변수 포함 줄은 일반 echo로 추가
+echo "목표: ${GOAL}" >> "$STATE_FILE"
+echo "Issue: ${ISSUE}" >> "$STATE_FILE"
+echo "" >> "$STATE_FILE"
+echo "## 미완료 Tasks" >> "$STATE_FILE"
+echo "${TASKS}" >> "$STATE_FILE"
+
+cat >> "$STATE_FILE" <<PROMPT_MID
+
+## karpathy 원칙 (매 반복 적용)
+
+- Read before Write: 수정 전 대상 파일 반드시 먼저 읽기
+- git add . 사용 금지 — 관련 파일만 명시적으로 지정
+- worktree 경로 내에서만 파일 수정 (main 워크트리 직접 수정 금지)
+- 요청한 것만 구현 — 추가 기능·리팩터 금지
+
+## 매 반복 실행 순서
+
+### 1. 상태 파악
+\`\`\`bash
+git status && git diff origin/main --name-only
+\`\`\`
+
+### 2. 미완료 Tasks 구현
+
+session-plan.md의 [ ] 항목을 위에서부터 순서대로 구현한다.
+각 항목 완료 시:
+  - [ ]를 [x]로 갱신 (session-plan.md 직접 수정)
+  - git add {관련 파일만} && git commit -m "{설명} (${ISSUE})"
+
+### 3. verify 실행
+
+3-1. git status → "nothing to commit" 확인
+3-2. 테스트 실행:
+\`\`\`bash
+${TEST_CMD}
+\`\`\`
+3-3. git diff origin/main --name-only → 의도한 파일만 변경됐는지 확인
+
+### 4. 판단
+
+모든 Tasks [x] 완료 AND verify 전부 통과:
+  → cleanup 스크립트 실행:
+    \`\`\`bash
+    bash "\${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-ralph.sh"
+    \`\`\`
+  → 다음 출력 후 promise:
+
+    ✅ verify 통과. Ralph 루프 종료.
+    변경 파일: (git diff origin/main --name-only 결과)
+    다음 단계: /submit
+
+  → <promise>READY_FOR_PR</promise>
+
+미완료 Tasks 있거나 verify 실패:
+  → 원인 분석 후 수정, 다음 반복에서 재시도
+  → promise 출력 절대 금지 (테스트 실패 = READY_FOR_PR 아님)
+PROMPT_MID
+
+# ── 완료 보고 ──────────────────────────────────────────────
+echo ""
+echo "🔄 harness-ralph 설정 완료!"
+echo ""
+echo "   목표: ${GOAL}"
+echo "   Issue: ${ISSUE}"
+echo "   Tasks: ${TASK_COUNT}개"
+echo "   max_iterations: ${MAX_ITER}"
+echo "   테스트: ${TEST_CMD}"
+echo ""
+echo "Stop hook이 활성화됩니다. 종료 시도 → 같은 프롬프트 재주입."
+echo "완료 조건: <promise>READY_FOR_PR</promise>"
+echo ""
+echo "수동 중단: /cancel-ralph"

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ralph
 description: execute + verify 단계를 Ralph Loop bypass 모드로 자동화. plan 확정 후 사용. verify 통과까지 반복 → READY_FOR_PR 출력 → submit 안내.
+allowed-tools: ["Bash(${CLAUDE_PLUGIN_ROOT}/scripts/setup-ralph.sh:*)", "Bash(${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-ralph.sh:*)"]
 ---
 
 # harness-ralph
@@ -8,156 +9,62 @@ description: execute + verify 단계를 Ralph Loop bypass 모드로 자동화. p
 plan이 확정된 상태에서 execute → verify 루프를 자동화한다.
 verify 통과까지 사람 개입 없이 반복한다.
 
-## 전제 조건 확인
+## 실행 순서
 
-### 1. session-plan.md 존재 확인
-```bash
-cat .claude/session-plan.md
-```
-없으면 → `plan` 스킬로 돌아간다.
-
-### 2. Worktree 확인
-```bash
-git worktree list | grep ".claude/worktrees"
-```
-없으면 → `issue` 스킬로 돌아간다. worktree 밖에서 ralph 시작 금지.
-
-### 3. 기존 Ralph 루프 확인
-```bash
-cat .claude/ralph-loop.local.md 2>/dev/null || echo "없음"
-```
-이미 활성 루프가 있으면 → 중단 여부를 사용자에게 확인한다.
-
-## bypass 권한 설정
-
-`.claude/settings.local.json`이 없으면 생성, 있으면 permissions.allow에 항목 추가.
+### 1. setup 스크립트 실행
 
 ```bash
-cat .claude/settings.local.json 2>/dev/null || echo '{"permissions":{"allow":[]}}'
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/setup-ralph.sh"
 ```
 
-이 파일에 다음 항목을 포함한다:
-```json
-{
-  "permissions": {
-    "allow": [
-      "Bash(*)",
-      "Read(*)",
-      "Edit(*)",
-      "Write(*)",
-      "Agent(*)",
-      "Skill(*)"
-    ]
-  }
-}
-```
+스크립트가 자동으로 처리하는 것:
+- `.claude/session-plan.md` 존재 + worktree 위치 확인
+- 기존 Ralph 루프 중복 실행 방지
+- `.claude/settings.local.json` 백업 → bypass 권한 추가
+- `.claude/ralph-loop.local.md` 상태 파일 생성 (session_id, max_iterations, karpathy 원칙 포함 프롬프트)
 
-저장 후 기존 권한 항목을 덮어쓰지 않도록 주의한다. 원래 있던 항목은 유지한다.
+에러가 있으면 스크립트가 메시지와 함께 종료된다:
+- `session-plan.md 없음` → `plan` 스킬로 먼저 계획 작성
+- `worktree 밖` → `issue` 스킬로 worktree 생성
+- `활성 루프 존재` → `/cancel-ralph` 또는 cleanup 스크립트 실행
 
-## Ralph 상태 파일 생성
+### 2. 첫 번째 반복 즉시 시작
 
-session-plan.md에서 goal, tasks, issue-번호, test-command를 읽어서
-`.claude/ralph-loop.local.md`를 생성한다.
-
-```bash
-SESSION_ID="${CLAUDE_CODE_SESSION_ID:-}"
-STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-
-cat > .claude/ralph-loop.local.md << 'STATE_EOF'
----
-active: true
-iteration: 1
-session_id: SESSION_ID_PLACEHOLDER
-max_iterations: 20
-completion_promise: "READY_FOR_PR"
-started_at: "STARTED_AT_PLACEHOLDER"
----
-
-[Ralph 프롬프트 — 아래 "Ralph 프롬프트 구조" 참조]
-STATE_EOF
-```
-
-SESSION_ID_PLACEHOLDER와 STARTED_AT_PLACEHOLDER는 실제 값으로 치환해서 작성한다.
-
-**max_iterations 기준**:
-- Tasks ≤ 3: 10
-- Tasks 4~6: 15
-- Tasks ≥ 7: 20
-
-## Ralph 프롬프트 구조
-
-상태 파일 `---` 이후에 삽입할 프롬프트. session-plan.md 내용을 기반으로 동적으로 작성한다.
-
-```
-sr-harness execute + verify 자동화 루프
-
-## 현재 컨텍스트
-목표: {session-plan.md의 goal}
-Issue: #{issue-번호}
-
-## 미완료 Tasks
-{session-plan.md에서 [ ] 항목 목록}
-
-## 매 반복마다 실행 순서
-
-### 1. 상태 파악
-git status && git diff origin/main --name-only
-
-### 2. 미완료 Tasks 구현
-session-plan.md의 [ ] 항목을 위에서 순서대로 구현한다.
-각 항목 완료 시:
-  - [ ]를 [x]로 갱신
-  - git add {파일} && git commit -m "{설명} (#{issue-번호})"
-
-### 3. verify 실행
-3-1. git status → "nothing to commit" 확인
-3-2. {test-command 또는 자동 감지된 테스트 명령어} 실행
-3-3. 변경 파일 목록이 의도한 범위인지 확인
-
-### 4. 판단
-모든 Tasks [x] 완료 AND verify 전부 통과:
-  → .claude/settings.local.json 에서 bypass 권한 항목 제거 (또는 빈 allow 배열로 복구)
-  → 다음 안내 출력:
-
-    ✅ verify 통과. Ralph 루프 종료.
-    변경 파일: {git diff origin/main --name-only 결과}
-    다음 단계: /submit
-
-  → <promise>READY_FOR_PR</promise>
-
-미완료 Tasks 있거나 verify 실패:
-  → 원인 분석 후 수정, 다음 반복에서 재시도
-  → promise 출력 금지 (테스트 실패 상태에서 READY_FOR_PR 출력 절대 금지)
-```
-
-## 상태 파일 생성 완료 후
-
-상태 파일을 생성한 직후, 첫 번째 반복을 즉시 시작한다.
-Ralph 프롬프트 내용을 그대로 따라 Step 1부터 실행한다.
+상태 파일 생성 직후, Ralph 프롬프트 내용을 따라 Step 1부터 실행한다.
+Stop hook이 이후 반복을 자동 처리한다.
 
 ## 중단 방법
 
-루프를 수동으로 멈춰야 하면:
-```bash
-rm .claude/ralph-loop.local.md
-# bypass 권한도 수동 복구
+```
+/cancel-ralph
 ```
 
-또는 `/cancel-ralph` 스킬 사용.
+또는 bypass 권한까지 함께 정리:
 
-## 완료 후 bypass 복구 세부 지침
-
-promise 출력 직전에 실행:
-
-기존 `.claude/settings.local.json`이 없었으면:
 ```bash
-rm -f .claude/settings.local.json
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-ralph.sh"
 ```
 
-기존 파일이 있었으면 (다른 항목 존재):
+`/cancel-ralph`는 상태 파일만 제거한다. bypass 권한까지 정리하려면 cleanup 스크립트를 직접 실행한다.
+
+## verify 통과 시 처리 (Ralph 루프 내 지침)
+
+모든 Tasks 완료 + verify 통과 확인 후:
+
 ```bash
-# ralph가 추가한 항목만 제거하고 나머지 유지
-# permissions.allow 에서 추가된 항목 삭제
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-ralph.sh"
+```
+
+실행 후 다음을 출력하고 promise를 선언한다:
+
+```
+✅ verify 통과. Ralph 루프 종료.
+변경 파일: (git diff origin/main --name-only)
+다음 단계: /submit
+```
+
+```
+<promise>READY_FOR_PR</promise>
 ```
 
 ## 금지 사항
@@ -166,4 +73,3 @@ rm -f .claude/settings.local.json
 - worktree 밖에서 실행 금지
 - Tasks 미완료 상태에서 promise 출력 금지
 - 테스트 실패 상태에서 promise 출력 금지
-- 기존 settings.local.json의 다른 설정을 삭제하거나 덮어쓰기 금지


### PR DESCRIPTION
## 변경 내용

`ralph-loop` 플러그인 구조와 비교 분석하여 발견한 6개 개선점을 수정한다.

## 수정 항목

| # | 문제 | 수정 방법 |
|---|------|----------|
| 1 | Session ID 버그 — heredoc 작은따옴표로 변수 미확장 | `setup-ralph.sh` 스크립트로 분리 |
| 2 | 전용 스크립트 없음 — 인라인 Bash 의존 | `scripts/setup-ralph.sh`, `scripts/cleanup-ralph.sh` 신규 추가 |
| 3 | `allowed-tools` 미설정 | SKILL.md frontmatter에 추가 |
| 4 | karpathy 원칙 누락 | setup 스크립트가 생성하는 Ralph 프롬프트에 포함 |
| 5 | bypass 권한 백업/복구 불안정 | `.claude/settings.local.json.ralph-backup` 자동 생성/복구 |
| 6 | `/cancel-ralph` 연동 부재 | `cleanup-ralph.sh` 별도 실행 가이드 추가 |

## 추가된 파일

- `scripts/setup-ralph.sh`: session-plan 파싱 → bypass 설정 → 상태 파일 생성
- `scripts/cleanup-ralph.sh`: bypass 복구 → 상태 파일 제거

Closes #30