### PR TITLE
fix: harness-ralph 0.7.3 — stop-hook cleanup, cancel-ralph 참조 제거, TASK_COUNT 버그

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "karpathy-guidelines와 issue-driven development가 구조적으로 통합된 커스텀 개발 워크플로우 하네스",
-    "version": "0.7.2"
+    "version": "0.7.3"
   },
   "plugins": [
     {
       "name": "sr-harness",
       "source": "./",
       "description": "karpathy-guidelines와 issue-driven development가 구조적으로 통합된 커스텀 개발 워크플로우 하네스",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "author": {
         "name": "SeokRae",
         "email": "kslbsh@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sr-harness",
   "description": "karpathy-guidelines와 issue-driven development가 구조적으로 통합된 커스텀 개발 워크플로우 하네스",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "author": {
     "name": "SeokRae",
     "email": "kslbsh@gmail.com"

--- a/hooks/stop-hook.sh
+++ b/hooks/stop-hook.sh
@@ -17,6 +17,20 @@ if [[ ! -f "$RALPH_STATE_FILE" ]]; then
   exit 0
 fi
 
+# Restore bypass permissions and remove state file on any termination path.
+# Called instead of bare `rm "$RALPH_STATE_FILE"` to avoid leaving
+# settings.local.json with blanket Bash(*) permissions after loop ends.
+cleanup_ralph() {
+  local BACKUP=".claude/settings.local.json.ralph-backup"
+  local SETTINGS=".claude/settings.local.json"
+  if [[ -f "$BACKUP" ]]; then
+    mv "$BACKUP" "$SETTINGS" 2>/dev/null || true
+  elif [[ -f "$SETTINGS" ]]; then
+    rm -f "$SETTINGS"
+  fi
+  rm -f "$RALPH_STATE_FILE"
+}
+
 # Parse markdown frontmatter (YAML between ---) and extract values
 FRONTMATTER=$(sed -n '/^---$/,/^---$/{ /^---$/d; p; }' "$RALPH_STATE_FILE")
 ITERATION=$(echo "$FRONTMATTER" | grep '^iteration:' | sed 's/iteration: *//')
@@ -42,7 +56,7 @@ if [[ ! "$ITERATION" =~ ^[0-9]+$ ]]; then
   echo "" >&2
   echo "   This usually means the state file was manually edited or corrupted." >&2
   echo "   Ralph loop is stopping. Run /ralph-loop again to start fresh." >&2
-  rm "$RALPH_STATE_FILE"
+  cleanup_ralph
   exit 0
 fi
 
@@ -53,14 +67,14 @@ if [[ ! "$MAX_ITERATIONS" =~ ^[0-9]+$ ]]; then
   echo "" >&2
   echo "   This usually means the state file was manually edited or corrupted." >&2
   echo "   Ralph loop is stopping. Run /ralph-loop again to start fresh." >&2
-  rm "$RALPH_STATE_FILE"
+  cleanup_ralph
   exit 0
 fi
 
 # Check if max iterations reached
 if [[ $MAX_ITERATIONS -gt 0 ]] && [[ $ITERATION -ge $MAX_ITERATIONS ]]; then
   echo "🛑 Ralph loop: Max iterations ($MAX_ITERATIONS) reached."
-  rm "$RALPH_STATE_FILE"
+  cleanup_ralph
   exit 0
 fi
 
@@ -72,7 +86,7 @@ if [[ ! -f "$TRANSCRIPT_PATH" ]]; then
   echo "   Expected: $TRANSCRIPT_PATH" >&2
   echo "   This is unusual and may indicate a Claude Code internal issue." >&2
   echo "   Ralph loop is stopping." >&2
-  rm "$RALPH_STATE_FILE"
+  cleanup_ralph
   exit 0
 fi
 
@@ -83,7 +97,7 @@ if ! grep -q '"role":"assistant"' "$TRANSCRIPT_PATH"; then
   echo "   Transcript: $TRANSCRIPT_PATH" >&2
   echo "   This is unusual and may indicate a transcript format issue" >&2
   echo "   Ralph loop is stopping." >&2
-  rm "$RALPH_STATE_FILE"
+  cleanup_ralph
   exit 0
 fi
 
@@ -99,7 +113,7 @@ LAST_LINES=$(grep '"role":"assistant"' "$TRANSCRIPT_PATH" | tail -n 100)
 if [[ -z "$LAST_LINES" ]]; then
   echo "⚠️  Ralph loop: Failed to extract assistant messages" >&2
   echo "   Ralph loop is stopping." >&2
-  rm "$RALPH_STATE_FILE"
+  cleanup_ralph
   exit 0
 fi
 
@@ -121,7 +135,7 @@ if [[ $JQ_EXIT -ne 0 ]]; then
   echo "   Error: $LAST_OUTPUT" >&2
   echo "   This may indicate a transcript format issue." >&2
   echo "   Ralph loop is stopping." >&2
-  rm "$RALPH_STATE_FILE"
+  cleanup_ralph
   exit 0
 fi
 
@@ -136,7 +150,7 @@ if [[ "$COMPLETION_PROMISE" != "null" ]] && [[ -n "$COMPLETION_PROMISE" ]]; then
   # == in [[ ]] does glob pattern matching which breaks with *, ?, [ characters
   if [[ -n "$PROMISE_TEXT" ]] && [[ "$PROMISE_TEXT" = "$COMPLETION_PROMISE" ]]; then
     echo "✅ Ralph loop: Detected <promise>$COMPLETION_PROMISE</promise>"
-    rm "$RALPH_STATE_FILE"
+    cleanup_ralph
     exit 0
   fi
 fi
@@ -159,7 +173,7 @@ if [[ -z "$PROMPT_TEXT" ]]; then
   echo "     • File was corrupted during writing" >&2
   echo "" >&2
   echo "   Ralph loop is stopping. Run /ralph-loop again to start fresh." >&2
-  rm "$RALPH_STATE_FILE"
+  cleanup_ralph
   exit 0
 fi
 

--- a/scripts/cleanup-ralph.sh
+++ b/scripts/cleanup-ralph.sh
@@ -8,25 +8,24 @@ STATE_FILE=".claude/ralph-loop.local.md"
 SETTINGS_FILE=".claude/settings.local.json"
 SETTINGS_BACKUP="${SETTINGS_FILE}.ralph-backup"
 
+# ── 상태 파일 먼저 제거 (백업 복구 실패와 독립적으로 보장) ────
+if [[ -f "$STATE_FILE" ]]; then
+  ITER=$(grep -m1 '^iteration:' "$STATE_FILE" | sed 's/iteration: *//' || echo "?")
+  rm -f "$STATE_FILE"
+  echo "🧹 Ralph 상태 파일 제거 (iteration: ${ITER})"
+else
+  echo "ℹ️  Ralph 상태 파일 없음 (이미 제거됨)"
+fi
+
 # ── bypass 권한 복구 ───────────────────────────────────────
 if [[ -f "$SETTINGS_BACKUP" ]]; then
-  mv "$SETTINGS_BACKUP" "$SETTINGS_FILE"
-  echo "🔒 settings.local.json 복구 완료 (백업에서 복원)"
+  mv "$SETTINGS_BACKUP" "$SETTINGS_FILE" && echo "🔒 settings.local.json 복구 완료 (백업에서 복원)" || echo "⚠️  백업 복구 실패 — 수동으로 확인 필요" >&2
 else
   # 백업 없음 = ralph가 처음 생성한 파일 → 삭제
   if [[ -f "$SETTINGS_FILE" ]]; then
     rm -f "$SETTINGS_FILE"
     echo "🔒 settings.local.json 제거 (ralph가 생성한 파일)"
   fi
-fi
-
-# ── 상태 파일 제거 ─────────────────────────────────────────
-if [[ -f "$STATE_FILE" ]]; then
-  ITER=$(grep '^iteration:' "$STATE_FILE" | sed 's/iteration: *//' || echo "?")
-  rm -f "$STATE_FILE"
-  echo "🧹 Ralph 상태 파일 제거 (iteration: ${ITER})"
-else
-  echo "ℹ️  Ralph 상태 파일 없음 (이미 제거됨)"
 fi
 
 echo "✅ harness-ralph cleanup 완료"

--- a/scripts/setup-ralph.sh
+++ b/scripts/setup-ralph.sh
@@ -15,7 +15,7 @@ if [[ ! -f "$PLAN_FILE" ]]; then
   exit 1
 fi
 
-WORKTREE_CHECK=$(git worktree list | grep "$(pwd)" | grep -v "bare" || true)
+WORKTREE_CHECK=$(git worktree list | grep -F "$(pwd)" | grep -v "bare" || true)
 if [[ -z "$WORKTREE_CHECK" ]]; then
   echo "❌ worktree 밖에서 실행됨. .claude/worktrees/ 안으로 이동하세요." >&2
   exit 1
@@ -23,7 +23,7 @@ fi
 
 if [[ -f "$STATE_FILE" ]]; then
   echo "⚠️  활성 Ralph 루프가 이미 존재합니다: $STATE_FILE" >&2
-  echo "   취소하려면: /cancel-ralph 또는 bash \"\${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-ralph.sh\"" >&2
+  echo "   취소하려면: bash \"\${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-ralph.sh\"" >&2
   exit 1
 fi
 
@@ -33,7 +33,7 @@ ISSUE=$(grep -m1 '#[0-9]' "$PLAN_FILE" | grep -o '#[0-9]*' | head -1 || echo "#?
 TEST_CMD=$(grep -m1 '^test-command:' "$PLAN_FILE" | sed 's/^test-command: *//' || echo "")
 
 # 미완료 Tasks 추출
-TASKS=$(grep '^\- \[ \]' "$PLAN_FILE" || echo "- [ ] (Tasks 항목 없음)")
+TASKS=$(grep '^\- \[ \]' "$PLAN_FILE" || echo "(미완료 Tasks 없음)")
 
 # max_iterations 결정
 TASK_COUNT=$(echo "$TASKS" | grep -c '^\- \[ \]' || echo 0)
@@ -181,4 +181,4 @@ echo ""
 echo "Stop hook이 활성화됩니다. 종료 시도 → 같은 프롬프트 재주입."
 echo "완료 조건: <promise>READY_FOR_PR</promise>"
 echo ""
-echo "수동 중단: /cancel-ralph"
+echo "수동 중단: bash \"\${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-ralph.sh\""

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -26,7 +26,7 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/setup-ralph.sh"
 에러가 있으면 스크립트가 메시지와 함께 종료된다:
 - `session-plan.md 없음` → `plan` 스킬로 먼저 계획 작성
 - `worktree 밖` → `issue` 스킬로 worktree 생성
-- `활성 루프 존재` → `/cancel-ralph` 또는 cleanup 스크립트 실행
+- `활성 루프 존재` → cleanup 스크립트 실행
 
 ### 2. 첫 번째 반복 즉시 시작
 
@@ -35,17 +35,11 @@ Stop hook이 이후 반복을 자동 처리한다.
 
 ## 중단 방법
 
-```
-/cancel-ralph
-```
-
-또는 bypass 권한까지 함께 정리:
-
 ```bash
 bash "${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-ralph.sh"
 ```
 
-`/cancel-ralph`는 상태 파일만 제거한다. bypass 권한까지 정리하려면 cleanup 스크립트를 직접 실행한다.
+상태 파일 제거 + bypass 권한 복구를 함께 처리한다.
 
 ## verify 통과 시 처리 (Ralph 루프 내 지침)
 

--- a/skills/start/SKILL.md
+++ b/skills/start/SKILL.md
@@ -30,6 +30,7 @@ description: sr-harness 세션 진입점. 모든 대화 시작 시 반드시 먼
 | 구현 계획 수립, 설계 | `plan` |
 | Issue 생성, 브랜치 생성 | `issue` |
 | 코드 작성, 기능 구현, PR 작업 | `execute` |
+| 자동으로 구현, ralph 모드, bypass로 실행 | `ralph` |
 | 버그, 테스트 실패, 에러 | `debug` |
 | PR 올리기, push, 리뷰 요청 | `submit` |
 | 머지, 마무리, 브랜치 정리 | `finish` |
@@ -63,6 +64,7 @@ superpowers의 유틸리티 스킬(dispatching-parallel-agents 등)은 그대로
 
 ```
 brainstorm → plan → issue → execute → verify → submit → [사용자 확인] → finish
-                               ↑ debug ↓
-                           review (리뷰 피드백 반영 시)
+                                        ↑ debug ↓
+                                    review (리뷰 피드백 반영 시)
+                               또는 ralph (bypass 자동화 모드)
 ```


### PR DESCRIPTION
## 수정 항목

| # | 심각도 | 수정 내용 |
|---|--------|----------|
| 1 | HIGH | `stop-hook.sh`에 `cleanup_ralph()` 함수 추가 — 모든 종료 경로에서 bypass 권한 복구 |
| 2 | MEDIUM | `/cancel-ralph` 참조 제거 — cleanup 스크립트 직접 실행으로 통일 |
| 3 | MEDIUM | Tasks fallback 텍스트 변경 → `grep -c` 패턴 불일치로 TASK_COUNT=0 정상 처리 |
| 4 | LOW | worktree grep에 `-F` 추가 (regex 메타문자 경로 안전) |
| 5 | LOW | cleanup에서 상태 파일을 먼저 삭제 후 백업 복구 — `set -e` 종료에도 상태 파일 정리 보장 |
| 6 | LOW | start 스킬 라우팅 표 + 워크플로우 다이어그램에 `ralph` 추가 |

Closes #34