### PR TITLE
fix: plugin.json hooks 중복 로드 오류 제거

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -28,6 +28,5 @@
     "./skills/abort",
     "./skills/pause",
     "./skills/ralph"
-  ],
-  "hooks": "./hooks/hooks.json"
+  ]
 }


### PR DESCRIPTION
Closes #36

## 변경 내용
- `plugin.json`에서 `"hooks": "./hooks/hooks.json"` 제거
- `hooks/hooks.json`은 플러그인 시스템이 자동 로드하므로 명시적 참조 불필요
- 제거하지 않으면 중복 로드 오류 발생