### PR TITLE
fix: Obsidian vault에서 worktree 스킵, 브랜치 직접 작업으로 전환

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "karpathy-guidelines와 issue-driven development가 구조적으로 통합된 커스텀 개발 워크플로우 하네스",
-    "version": "0.7.4"
+    "version": "0.7.5"
   },
   "plugins": [
     {
       "name": "sr-harness",
       "source": "./",
       "description": "karpathy-guidelines와 issue-driven development가 구조적으로 통합된 커스텀 개발 워크플로우 하네스",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "author": {
         "name": "SeokRae",
         "email": "kslbsh@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sr-harness",
   "description": "karpathy-guidelines와 issue-driven development가 구조적으로 통합된 커스텀 개발 워크플로우 하네스",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "author": {
     "name": "SeokRae",
     "email": "kslbsh@gmail.com"

--- a/skills/execute/SKILL.md
+++ b/skills/execute/SKILL.md
@@ -8,14 +8,26 @@ description: 구현 계획을 실행하는 스킬. "구현해줘", "만들어줘
 구현 시작 전 karpathy 체크포인트를 통과해야 한다.
 단계별로 실행하고, 각 단계가 끝나면 verify 후 다음으로 넘어간다.
 
-## 전제 조건 (Worktree 확인)
+## 전제 조건 (브랜치/Worktree 확인)
 
-현재 작업 디렉토리가 worktree(`.claude/worktrees/{description}`) 안인지 확인한다.
+먼저 프로젝트 유형을 감지한다:
+
+```bash
+ls .obsidian/ 2>/dev/null && echo "vault" || echo "code"
+```
+
+**코드 프로젝트**: 현재 디렉토리가 worktree(`.claude/worktrees/{description}`) 안인지 확인한다.
 - 맞으면 → 진행
 - 아니면 → `issue`로 돌아가서 worktree 생성
 
 ```bash
 git worktree list | grep "$(pwd)"
+```
+
+**Obsidian vault**: feature 브랜치에 있는지 확인한다. main이면 → `issue`로 돌아가서 브랜치 생성.
+
+```bash
+git branch --show-current  # feature/* 여야 함, main이면 안 됨
 ```
 
 ## 시작 전 체크포인트 (karpathy §1 Think Before Coding)
@@ -90,7 +102,7 @@ git commit -m "{type}: {설명} (#N)"
 
 ### 원칙
 
-- 동일 worktree + 동일 feature 브랜치 + 순차 dispatch → PR 충돌 없음
+- 동일 feature 브랜치 + 순차 dispatch → PR 충돌 없음 (코드 프로젝트는 동일 worktree에서)
 - 서브에이전트 병렬 dispatch 절대 금지
 - 각 태스크 완료 후 2단계 리뷰(스펙 → 코드 품질) 통과 시 다음 태스크 진행
 
@@ -121,7 +133,8 @@ git commit -m "{type}: {설명} (#N)"
 
 ### 충돌 방지 규칙 (서브에이전트에게 명시 전달)
 
-- 모든 파일 수정은 반드시 전달받은 worktree 경로 내에서 수행 — main 워크트리 파일 직접 수정 금지
+- 코드 프로젝트: 모든 파일 수정은 반드시 전달받은 worktree 경로 내에서 수행 — main 워크트리 파일 직접 수정 금지
+- Vault 프로젝트: feature 브랜치에서 직접 수정 (worktree 없음)
 - `git add .` 사용 금지 — 태스크 관련 파일만 명시적으로 지정
 - 커밋 전 `git pull --rebase origin {브랜치명}` 실행
 - 모든 커밋에 이슈 번호 포함: `feat: 설명 (#이슈번호)`

--- a/skills/issue/SKILL.md
+++ b/skills/issue/SKILL.md
@@ -31,9 +31,15 @@ git checkout -b feature/{issue-number}-{short-description}
 - 다른 feature 브랜치에서 분기 (체인 브랜치 금지)
 - 한 브랜치에 여러 Issue 혼재
 
-### 3. Worktree 생성 (격리 의무)
+### 3. 프로젝트 유형 감지 후 격리 방식 결정
+
 ```bash
-git checkout main
+ls .obsidian/ 2>/dev/null && echo "vault" || echo "code"
+```
+
+#### 코드 프로젝트 (`.obsidian/` 없음) → Worktree 생성
+
+```bash
 git worktree add .claude/worktrees/{short-description} feature/{issue-number}-{short-description}
 ```
 
@@ -44,12 +50,33 @@ git worktree add .claude/worktrees/{short-description} feature/{issue-number}-{s
 - 이름: 브랜치의 `{short-description}` 부분 그대로 사용
 - `.gitignore`에 `.claude/worktrees/` 없으면 추가 후 커밋
 
+#### Obsidian vault (`.obsidian/` 있음) → 브랜치에서 직접 작업
+
+worktree를 생성하지 않는다. Obsidian은 vault 루트 하나만 바라보기 때문에
+worktree 파일은 머지 전까지 Obsidian에서 보이지 않아 의미가 없다.
+feature 브랜치에서 직접 작업하고, 작업 결과를 바로 Obsidian에서 확인할 수 있다.
+
+```bash
+git checkout feature/{issue-number}-{short-description}
+```
+
 ### 4. 확인 출력
+
+코드 프로젝트:
 ```
 ✅ Issue #N 생성: {제목}
 ✅ 브랜치 생성: feature/{N}-{description}
 ✅ Worktree 생성: .claude/worktrees/{description}
 ✅ 현재 위치: .claude/worktrees/{description}
+
+다음 단계: execute
+```
+
+Obsidian vault:
+```
+✅ Issue #N 생성: {제목}
+✅ 브랜치 생성: feature/{N}-{description}
+ℹ️  Vault 프로젝트 — worktree 없이 브랜치에서 직접 작업
 
 다음 단계: execute
 ```


### PR DESCRIPTION
## 변경 내용

Obsidian vault 프로젝트(`.obsidian/` 디렉토리로 감지)에서 `issue` 스킬이 worktree를 생성하지 않고 feature 브랜치에서 직접 작업하도록 수정.

### 문제
Obsidian은 vault 루트 하나만 바라봄 → worktree 내 파일은 PR 머지 전까지 Obsidian에서 보이지 않아 작업 확인 불가.

### 수정된 스킬
- **`issue`**: Step 3에 `.obsidian/` 감지 로직 추가 — vault이면 worktree 생성 스킵, 브랜치 직접 체크아웃
- **`execute`**: 전제 조건 체크를 프로젝트 유형에 따라 분기 — vault이면 feature 브랜치 여부만 확인

### 버전
0.7.4 → 0.7.5 (PATCH)

Closes #40