### PR TITLE
feat: finish 스킬에 session-plan.md 자동 삭제 추가

### DIFF
--- a/skills/finish/SKILL.md
+++ b/skills/finish/SKILL.md
@@ -37,16 +37,17 @@ git pull origin main
 git worktree remove .claude/worktrees/{description}
 ```
 
-### 5. 완료 보고
+### 5. 플랜 파일 삭제
+```bash
+rm -f .claude/session-plan.md
+```
+파일이 없으면 그냥 넘어간다.
+
+### 6. 완료 보고
 ```
 ✅ PR #{PR-number} 머지 완료
 ✅ Issue #{issue-number} close
 ✅ 브랜치 삭제: feature/{N}-{description}
 ✅ main 동기화 완료
+✅ session-plan.md 삭제
 ```
-
-## session-plan.md 정리
-
-머지 완료 후:
-- 완료 → 파일 삭제
-- 다음 세션 작업이 남아 있으면 → 새 session-plan.md 작성 권장


### PR DESCRIPTION
Closes #42

## 변경 사항

`finish` 스킬 실행 순서에 Step 5 추가:

```bash
rm -f .claude/session-plan.md
```

- 파일이 없어도 오류 없이 넘어감 (`-f` 플래그)
- 완료 보고에 `✅ session-plan.md 삭제` 항목 추가
- 기존 `## session-plan.md 정리` 섹션 제거 (명령 없이 텍스트만 있던 부분)