### PR TITLE
feat: dev-coding-principles 스킬 추가

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "karpathy-guidelines와 issue-driven development가 구조적으로 통합된 커스텀 개발 워크플로우 하네스",
-    "version": "0.7.5"
+    "version": "0.8.0"
   },
   "plugins": [
     {
       "name": "sr-harness",
       "source": "./",
       "description": "karpathy-guidelines와 issue-driven development가 구조적으로 통합된 커스텀 개발 워크플로우 하네스",
-      "version": "0.7.5",
+      "version": "0.8.0",
       "author": {
         "name": "SeokRae",
         "email": "kslbsh@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sr-harness",
   "description": "karpathy-guidelines와 issue-driven development가 구조적으로 통합된 커스텀 개발 워크플로우 하네스",
-  "version": "0.7.6",
+  "version": "0.8.0",
   "author": {
     "name": "SeokRae",
     "email": "kslbsh@gmail.com"
@@ -27,6 +27,7 @@
     "./skills/review",
     "./skills/abort",
     "./skills/pause",
-    "./skills/ralph"
+    "./skills/ralph",
+    "./skills/dev-coding-principles"
   ]
 }

--- a/README.ko.md
+++ b/README.ko.md
@@ -115,6 +115,7 @@ start
 | `execute` | 구현 실행 · karpathy 체크포인트 |
 | `finish` | push + PR (Closes #N) |
 | `debug` | 진단 우선 디버깅 |
+| `dev-coding-principles` | 코딩 품질 체크리스트 — 네이밍·예외처리·테스트 |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ start
 | `finish` | Merge + delete branch + pull main |
 | `abort` | Cancel work · clean up branch |
 | `pause` | Suspend session · hand off to next session |
+| `dev-coding-principles` | Coding quality checklist — Naming, Exception Handling, Test |
 
 ---
 

--- a/skills/dev-coding-principles/SKILL.md
+++ b/skills/dev-coding-principles/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: dev-coding-principles
+description: 코딩 품질 원칙 체크리스트. execute 시작 전 또는 코드 작성 중 참조. 네이밍·예외 처리·테스트 세 섹션으로 구성. Keywords: 코딩 원칙, 네이밍, 예외처리, 테스트, 품질, coding standards, naming, exception, test
+---
+
+# dev-coding-principles
+
+코드를 작성하기 전, 각 섹션의 원칙을 확인하고 구현에 반영한다.
+
+## §1 Naming
+
+**목표**: 코드를 읽는 사람이 의미를 추론하지 않아도 된다.
+
+- **도메인 언어 우선**: 클래스·메서드·변수 이름은 비즈니스 용어를 그대로 사용한다.
+  - `PaymentProcessor` ✅ / `DataHandler` ❌
+- **의도 드러내는 동사구**: 메서드는 행위와 대상이 명확한 동사구로 명명한다.
+  - `findActiveOrders()` ✅ / `getList()` ❌
+  - `calculateSettlementAmount()` ✅ / `calc()` ❌
+- **약어 금지**: `Mgr`, `Svc`, `Util`, `Hlpr` → 역할을 명시한 전체 이름 사용
+- **boolean**: `is` / `has` / `can` 접두사 필수
+  - `isExpired()` ✅ / `expired()` ❌
+- **컬렉션**: 복수형 명사 사용
+  - `List<Order> orders` ✅ / `List<Order> orderList` ❌
+
+## §2 Exception Handling
+
+**목표**: 예외는 숨기지 않고, 발생한 원인과 문맥을 담는다.
+
+- **비즈니스 예외는 unchecked**: `RuntimeException` 계열 사용 — checked exception은 복구 가능한 I/O에만 허용
+- **원인 + 문맥 메시지**: `"결제 실패"` ❌ → `"결제 실패: orderId=" + orderId + ", reason=" + reason` ✅
+- **catch-and-ignore 금지**: 빈 catch 블록 또는 `e.printStackTrace()` 만 있는 블록 작성 금지 — 최소한 로깅 필수
+- **처리 가능한 계층에서만 catch**: 처리 불가능한 계층에서 catch 후 다시 throw 시 원본 예외를 cause로 전달
+  ```java
+  throw new PaymentException("결제 처리 실패: orderId=" + orderId, e);
+  ```
+- **외부 API 예외 래핑**: 외부 의존성(DB, HTTP)의 예외는 도메인 예외로 변환하여 전파
+
+## §3 Test
+
+**목표**: 테스트는 코드의 동작 명세다 — 구현이 아닌 의도를 검증한다.
+
+- **given-when-then 구조** 필수:
+  ```java
+  // given
+  Order order = OrderFixture.pendingOrder();
+  // when
+  PaymentResult result = paymentService.pay(order);
+  // then
+  assertThat(result.isSuccess()).isTrue();
+  ```
+- **테스트 이름은 한국어 의도 표현**:
+  - `결제_금액이_0원이면_예외를_던진다()` ✅ / `test1()` ❌
+- **단위 테스트 우선**: 도메인 로직(Entity, VO, Domain Service)은 외부 의존 없이 단위 테스트
+- **통합 테스트 경계**: 외부 경계(Repository, HTTP Client)만 통합 테스트 — 비즈니스 로직 중복 검증 금지
+- **픽스처 분리**: 테스트 데이터 생성은 `*Fixture` 클래스로 분리하여 재사용
+- **단언은 구체적으로**: `assertThat(result).isNotNull()` ❌ → `assertThat(result.getStatus()).isEqualTo(COMPLETED)` ✅
+
+## 체크리스트 (execute 시작 전)
+
+```
+§1 Naming
+[ ] 도메인 언어를 사용했는가?
+[ ] 메서드 이름에서 행위가 명확한가?
+[ ] 약어를 사용하지 않았는가?
+
+§2 Exception Handling
+[ ] 비즈니스 예외는 unchecked인가?
+[ ] 예외 메시지에 원인과 문맥이 포함되어 있는가?
+[ ] 빈 catch 블록이 없는가?
+
+§3 Test
+[ ] given-when-then 구조인가?
+[ ] 테스트 이름이 한국어로 의도를 표현하는가?
+[ ] 단위/통합 테스트 경계가 올바른가?
+```

--- a/skills/execute/SKILL.md
+++ b/skills/execute/SKILL.md
@@ -41,6 +41,8 @@ git branch --show-current  # feature/* 여야 함, main이면 안 됨
 [ ] 성공 기준이 정의되어 있는가? → plan의 verify 기준 확인
 ```
 
+코드 프로젝트인 경우 → `dev-coding-principles` 스킬을 로드하고 원칙(§1 Naming, §2 Exception Handling, §3 Test)을 구현에 적용한다.
+
 ## 실행 모드 판단
 
 플랜 파일(`.claude/session-plan.md`)을 읽어 제외 조건을 체크한다.


### PR DESCRIPTION
## 변경 내용

코드 작성 시 참조할 코딩 품질 원칙 스킬을 추가하고, execute 체크포인트에서 자동으로 로드되도록 연결했습니다.

### 추가된 스킬: `dev-coding-principles`
- **§1 Naming** — 도메인 언어 우선, 의도 드러내는 동사구, boolean 접두사, 약어 금지
- **§2 Exception Handling** — unchecked 비즈니스 예외, 원인+문맥 메시지, catch-and-ignore 금지
- **§3 Test** — given-when-then 구조, 한국어 테스트명, 단위/통합 테스트 경계

### execute 연결
`시작 전 체크포인트` 섹션에 코드 프로젝트 시 `dev-coding-principles` 스킬 로드 안내 추가

### 버전
plugin.json + marketplace.json: `0.7.6` → `0.8.0` (MINOR bump, 스킬 추가)

## 테스트

- [ ] `dev-coding-principles` 스킬 단독 호출 시 세 섹션 정상 로드 확인
- [ ] execute 실행 시 체크포인트에서 참조 문구 표시 확인

Closes #48