### PR TITLE
feat: dev-architecture 스킬 추가

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "karpathy-guidelines와 issue-driven development가 구조적으로 통합된 커스텀 개발 워크플로우 하네스",
-    "version": "0.8.0"
+    "version": "0.9.0"
   },
   "plugins": [
     {
       "name": "sr-harness",
       "source": "./",
       "description": "karpathy-guidelines와 issue-driven development가 구조적으로 통합된 커스텀 개발 워크플로우 하네스",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "author": {
         "name": "SeokRae",
         "email": "kslbsh@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sr-harness",
   "description": "karpathy-guidelines와 issue-driven development가 구조적으로 통합된 커스텀 개발 워크플로우 하네스",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "author": {
     "name": "SeokRae",
     "email": "kslbsh@gmail.com"
@@ -28,6 +28,7 @@
     "./skills/abort",
     "./skills/pause",
     "./skills/ralph",
-    "./skills/dev-coding-principles"
+    "./skills/dev-coding-principles",
+    "./skills/dev-architecture"
   ]
 }

--- a/README.ko.md
+++ b/README.ko.md
@@ -116,6 +116,7 @@ start
 | `finish` | push + PR (Closes #N) |
 | `debug` | 진단 우선 디버깅 |
 | `dev-coding-principles` | 코딩 품질 체크리스트 — 네이밍·예외처리·테스트 |
+| `dev-architecture` | 아키텍처 체크리스트 — Hexagonal·레이어 분리·패키지 구조 |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ start
 | `abort` | Cancel work · clean up branch |
 | `pause` | Suspend session · hand off to next session |
 | `dev-coding-principles` | Coding quality checklist — Naming, Exception Handling, Test |
+| `dev-architecture` | Architecture checklist — Hexagonal, Layer Separation, Package Structure |
 
 ---
 

--- a/skills/dev-architecture/SKILL.md
+++ b/skills/dev-architecture/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: dev-architecture
+description: 아키텍처 설계 원칙 체크리스트. execute 시작 전 또는 설계 중 참조. Hexagonal Architecture·레이어 분리·패키지 구조 세 섹션으로 구성. Keywords: 아키텍처, hexagonal, 레이어, 패키지, 설계, architecture, layer, package, ports and adapters
+---
+
+# dev-architecture
+
+코드 구조를 설계하기 전, 각 섹션의 원칙을 확인하고 구현에 반영한다.
+
+## §1 Hexagonal Architecture (Ports & Adapters)
+
+**목표**: 도메인 로직이 외부 시스템(DB, HTTP, MQ)에 의존하지 않는다.
+
+- **의존 방향은 항상 안쪽으로**: 인프라 → 애플리케이션 → 도메인 (역방향 금지)
+- **Port**: 도메인이 정의하는 인터페이스
+  - `Inbound Port` — 외부에서 도메인을 호출하는 진입점 (UseCase 인터페이스)
+  - `Outbound Port` — 도메인이 외부에 요청하는 계약 (Repository, ExternalService 인터페이스)
+- **Adapter**: Port를 구현하는 인프라 코드
+  - `Inbound Adapter` — Controller, Consumer, Scheduler (Port 호출)
+  - `Outbound Adapter` — JpaRepository 구현체, HTTP Client 구현체 (Port 구현)
+- **도메인은 프레임워크 어노테이션을 갖지 않는다**: `@Entity`, `@Component` 등 인프라 어노테이션은 Adapter 계층에만 허용
+- **테스트 가능성 확보**: Port를 Fake/Mock으로 교체할 수 있어야 한다
+
+## §2 Layer Separation
+
+**목표**: 각 레이어는 자신의 책임만 갖고, 허용된 방향으로만 의존한다.
+
+| 레이어 | 책임 | 의존 허용 |
+|--------|------|----------|
+| `presentation` | 요청/응답 변환, 입력 검증 | application |
+| `application` | 유스케이스 조율, 트랜잭션 경계 | domain |
+| `domain` | 비즈니스 규칙, 불변식 | 없음 (순수 Java) |
+| `infrastructure` | DB, HTTP, MQ 구현 | domain (Port 구현) |
+
+**원칙**:
+- **레이어 간 객체 직접 전달 금지**: 각 레이어 경계에서 전용 DTO/Command/Event로 변환
+  - Controller → `Command` → UseCase ✅ / Controller → `Entity` → UseCase ❌
+- **트랜잭션은 Application 레이어에서 시작**: Domain·Infrastructure에 `@Transactional` 금지
+- **도메인 로직은 Application에 두지 않는다**: 조건 분기·계산은 Domain으로 이동
+
+## §3 Package Structure
+
+**목표**: 패키지 이름만 보고 어느 레이어·어느 도메인인지 파악할 수 있다.
+
+**도메인 중심 패키지 구성**:
+```
+com.example.{service}/
+├── {domain}/                    # 도메인 단위로 최상위 구성
+│   ├── domain/                  # Entity, VO, DomainService, Port 인터페이스
+│   │   ├── model/               # Entity, VO, Aggregate
+│   │   ├── service/             # DomainService
+│   │   └── port/
+│   │       ├── in/              # Inbound Port (UseCase 인터페이스)
+│   │       └── out/             # Outbound Port (Repository 등 인터페이스)
+│   ├── application/             # UseCase 구현체, Command, Event
+│   │   ├── service/             # UseCase 구현
+│   │   └── dto/                 # Command, Query, Result
+│   ├── adapter/                 # Inbound/Outbound Adapter
+│   │   ├── in/
+│   │   │   ├── web/             # Controller, Request/Response DTO
+│   │   │   └── consumer/        # MQ Consumer
+│   │   └── out/
+│   │       ├── persistence/     # JPA Entity, Repository 구현
+│   │       └── client/          # HTTP Client 구현
+│   └── config/                  # 도메인별 Spring 설정
+```
+
+**명명 규칙**:
+- UseCase 인터페이스: `{동사}{도메인}UseCase` → `PayOrderUseCase`
+- UseCase 구현체: `{도메인}{동사}Service` → `OrderPaymentService`
+- Outbound Port: `{도메인}Repository`, `{외부시스템}Port`
+- Command/Query: `{동사}{도메인}Command`, `{조건}{도메인}Query`
+
+## 체크리스트 (execute 시작 전)
+
+```
+§1 Hexagonal
+[ ] 도메인이 인프라에 의존하지 않는가?
+[ ] Inbound/Outbound Port가 도메인 레이어에 정의되어 있는가?
+[ ] 도메인에 프레임워크 어노테이션이 없는가?
+
+§2 Layer Separation
+[ ] 레이어 간 객체 변환이 경계에서 이루어지는가?
+[ ] 트랜잭션이 Application 레이어에서 시작되는가?
+[ ] 도메인 로직이 Application에 누수되지 않았는가?
+
+§3 Package Structure
+[ ] 패키지 이름에서 레이어와 도메인이 명확한가?
+[ ] UseCase/Port/Adapter 명명 규칙을 따르는가?
+```

--- a/skills/execute/SKILL.md
+++ b/skills/execute/SKILL.md
@@ -42,6 +42,7 @@ git branch --show-current  # feature/* 여야 함, main이면 안 됨
 ```
 
 코드 프로젝트인 경우 → `dev-coding-principles` 스킬을 로드하고 원칙(§1 Naming, §2 Exception Handling, §3 Test)을 구현에 적용한다.
+코드 프로젝트인 경우 → `dev-architecture` 스킬을 로드하고 아키텍처 원칙(§1 Hexagonal, §2 Layer Separation, §3 Package Structure)을 구현에 적용한다.
 
 ## 실행 모드 판단
 


### PR DESCRIPTION
## 변경 내용

아키텍처 설계 원칙 스킬을 추가하고, execute 체크포인트에서 자동으로 로드되도록 연결했습니다.

### 추가된 스킬: `dev-architecture`
- **§1 Hexagonal Architecture** — Inbound/Outbound Port·Adapter, 의존 방향 규칙, 도메인 순수성
- **§2 Layer Separation** — Presentation·Application·Domain·Infrastructure 의존 방향, 레이어 간 객체 변환
- **§3 Package Structure** — 도메인 중심 패키지 구성, UseCase/Port/Adapter 명명 규칙

### execute 연결
dev-coding-principles 참조 바로 아래에 dev-architecture 로드 안내 추가

### 버전
plugin.json + marketplace.json: `0.8.0` → `0.9.0` (MINOR bump, 스킬 추가)

## 테스트

- [ ] `dev-architecture` 스킬 단독 호출 시 세 섹션 정상 로드 확인
- [ ] execute 실행 시 체크포인트에서 참조 문구 표시 확인

Closes #50