### PR TITLE
feat: dev-stack-java 스킬 추가

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "karpathy-guidelines와 issue-driven development가 구조적으로 통합된 커스텀 개발 워크플로우 하네스",
-    "version": "0.9.0"
+    "version": "0.10.0"
   },
   "plugins": [
     {
       "name": "sr-harness",
       "source": "./",
       "description": "karpathy-guidelines와 issue-driven development가 구조적으로 통합된 커스텀 개발 워크플로우 하네스",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "author": {
         "name": "SeokRae",
         "email": "kslbsh@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sr-harness",
   "description": "karpathy-guidelines와 issue-driven development가 구조적으로 통합된 커스텀 개발 워크플로우 하네스",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "author": {
     "name": "SeokRae",
     "email": "kslbsh@gmail.com"
@@ -29,6 +29,7 @@
     "./skills/pause",
     "./skills/ralph",
     "./skills/dev-coding-principles",
-    "./skills/dev-architecture"
+    "./skills/dev-architecture",
+    "./skills/dev-stack-java"
   ]
 }

--- a/README.ko.md
+++ b/README.ko.md
@@ -117,6 +117,17 @@ start
 | `debug` | 진단 우선 디버깅 |
 | `dev-coding-principles` | 코딩 품질 체크리스트 — 네이밍·예외처리·테스트 |
 | `dev-architecture` | 아키텍처 체크리스트 — Hexagonal·레이어 분리·패키지 구조 |
+| `dev-stack-java` | Java/Spring Boot 관용구 — Spring·JPA·예외처리 (프로젝트별 활성화) |
+
+### 스택별 스킬 (프로젝트 CLAUDE.md 선언)
+
+`dev-stack-java`는 execute에 전역으로 연결되지 않는다 — 프로젝트 `CLAUDE.md`에 한 줄을 추가하여 활성화한다:
+
+```markdown
+execute 실행 시 `dev-stack-java` 스킬을 로드하고 Java/Spring Boot 관용구를 구현에 적용한다.
+```
+
+execute 체크포인트를 가볍게 유지하면서 프로젝트별 스택 커스터마이징이 가능하다.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,17 @@ start
 | `pause` | Suspend session · hand off to next session |
 | `dev-coding-principles` | Coding quality checklist — Naming, Exception Handling, Test |
 | `dev-architecture` | Architecture checklist — Hexagonal, Layer Separation, Package Structure |
+| `dev-stack-java` | Java/Spring Boot idioms — Spring, JPA, Exception & Response (project-scoped) |
+
+### Stack-specific skills (project CLAUDE.md)
+
+`dev-stack-java` is not wired into `execute` globally — activate it per project by adding one line to the project `CLAUDE.md`:
+
+```markdown
+execute 실행 시 `dev-stack-java` 스킬을 로드하고 Java/Spring Boot 관용구를 구현에 적용한다.
+```
+
+This keeps the execute checkpoint lean while allowing per-project stack customization.
 
 ---
 

--- a/skills/dev-stack-java/SKILL.md
+++ b/skills/dev-stack-java/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: dev-stack-java
+description: Java/Spring Boot 관용구 체크리스트. Java 프로젝트의 execute 시 참조. Spring Boot·JPA·예외처리 패턴 세 섹션으로 구성. 프로젝트 CLAUDE.md에 선언하여 활성화. Keywords: Java, Spring Boot, JPA, 스프링, 관용구, spring idioms, dependency injection, transaction, exception handler
+---
+
+# dev-stack-java
+
+Java/Spring Boot 프로젝트에서 코드를 작성하기 전, 각 섹션의 관용구를 확인하고 구현에 반영한다.
+
+> **활성화 방법**: 프로젝트 `CLAUDE.md`에 아래 한 줄을 추가한다.
+> ```
+> execute 실행 시 `dev-stack-java` 스킬을 로드하고 Java/Spring Boot 관용구를 구현에 적용한다.
+> ```
+
+## §1 Spring Boot Idioms
+
+**목표**: 프레임워크 기능을 올바르게 사용하고 숨겨진 부작용을 방지한다.
+
+- **Constructor injection 필수**: 필드 주입(`@Autowired` 필드) 금지 — 테스트 불가, 순환 의존 감지 불가
+  ```java
+  // ✅
+  private final OrderRepository orderRepository;
+  public OrderService(OrderRepository orderRepository) {
+      this.orderRepository = orderRepository;
+  }
+  // ❌
+  @Autowired
+  private OrderRepository orderRepository;
+  ```
+- **`@Transactional(readOnly = true)` 기본**: 조회 서비스는 readOnly 기본 적용, 쓰기 메서드에만 `@Transactional` 명시
+  ```java
+  @Transactional(readOnly = true)  // 클래스 레벨
+  public class OrderQueryService {
+      @Transactional  // 쓰기 메서드만 override
+      public void cancel(Long orderId) { ... }
+  }
+  ```
+- **`@ConfigurationProperties` 우선**: 설정값이 2개 이상이면 `@Value` 대신 `@ConfigurationProperties` 클래스로 묶기
+- **스테레오타입 구분**:
+  - `@Service` — 비즈니스 로직 (UseCase 구현체)
+  - `@Repository` — 데이터 접근 (Adapter 구현체)
+  - `@Component` — 위 두 범주에 속하지 않는 빈
+- **프로퍼티 검증**: `@ConfigurationProperties` + `@Validated` + `@NotNull` 조합으로 시작 시점에 실패
+
+## §2 JPA
+
+**목표**: 성능 함정을 피하고 도메인 의미를 Entity에 담는다.
+
+- **LAZY 로딩 기본**: 모든 연관관계는 `fetch = FetchType.LAZY` — 필요한 곳에서 fetch join으로 명시 로딩
+  ```java
+  @ManyToOne(fetch = FetchType.LAZY)  // ✅
+  @ManyToOne  // ❌ (기본이 EAGER)
+  ```
+- **N+1 방지**: 컬렉션 조회 시 반드시 fetch join 또는 `@BatchSize` 적용
+  ```java
+  @Query("SELECT o FROM Order o JOIN FETCH o.items WHERE o.status = :status")
+  ```
+- **Rich Domain Model**: 비즈니스 규칙은 Entity 메서드로 — 서비스에서 Entity 필드 직접 조작 금지
+  ```java
+  // ✅ Entity 메서드
+  order.cancel();
+  // ❌ 서비스에서 직접 조작
+  order.setStatus(CANCELLED);
+  ```
+- **Auditing 필수**: BaseEntity에 `@CreatedDate`, `@LastModifiedDate` 적용, 모든 Entity가 상속
+- **Soft Delete**: 데이터 복구 가능성이 있으면 `deletedAt` 컬럼 + `@Where(clause = "deleted_at IS NULL")`
+- **`equals`/`hashCode`**: 비즈니스 키(자연 키)로 구현 — Auto-generated ID로 구현 금지
+
+## §3 Exception & Response
+
+**목표**: 예외와 응답 형식이 전 레이어에서 일관된다.
+
+- **전역 예외 처리**: `@RestControllerAdvice` + `@ExceptionHandler`로 모든 예외를 한 곳에서 처리
+  ```java
+  @RestControllerAdvice
+  public class GlobalExceptionHandler {
+      @ExceptionHandler(BusinessException.class)
+      public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+          return ResponseEntity.status(e.getStatus()).body(ErrorResponse.of(e));
+      }
+  }
+  ```
+- **통일된 에러 응답**:
+  ```java
+  public record ErrorResponse(String code, String message) {
+      public static ErrorResponse of(BusinessException e) {
+          return new ErrorResponse(e.getCode(), e.getMessage());
+      }
+  }
+  ```
+- **HTTP 상태 코드 매핑 원칙**:
+  - `400 Bad Request` — 입력 검증 실패, 비즈니스 규칙 위반
+  - `401 Unauthorized` — 인증 필요
+  - `403 Forbidden` — 권한 없음
+  - `404 Not Found` — 리소스 없음
+  - `409 Conflict` — 상태 충돌 (중복 결제 등)
+  - `500 Internal Server Error` — 예상치 못한 오류 (절대 비즈니스 예외에 사용 금지)
+- **비즈니스 예외 계층**:
+  ```
+  BusinessException (abstract, RuntimeException)
+  ├── NotFoundException (404)
+  ├── ConflictException (409)
+  └── InvalidRequestException (400)
+  ```
+- **검증 실패 응답**: `@Valid` + `MethodArgumentNotValidException` 처리 시 필드별 오류 목록 반환
+
+## 체크리스트 (execute 시작 전)
+
+```
+§1 Spring Boot
+[ ] Constructor injection을 사용하는가?
+[ ] 조회 서비스에 @Transactional(readOnly=true)가 적용됐는가?
+[ ] 설정값이 @ConfigurationProperties로 묶여 있는가?
+
+§2 JPA
+[ ] 모든 연관관계가 LAZY 로딩인가?
+[ ] N+1이 발생할 수 있는 컬렉션 조회에 fetch join이 있는가?
+[ ] 비즈니스 로직이 Entity 메서드에 있는가?
+
+§3 Exception & Response
+[ ] @RestControllerAdvice가 전역 예외를 처리하는가?
+[ ] 에러 응답 형식이 ErrorResponse로 통일됐는가?
+[ ] HTTP 상태 코드가 의미에 맞게 매핑됐는가?
+```


### PR DESCRIPTION
## 변경 내용

Java/Spring Boot 프로젝트 전용 관용구 스킬을 추가했습니다.
dev-coding-principles·dev-architecture와 달리 execute에 전역 연결하지 않고, 프로젝트 CLAUDE.md에서 선언하는 방식으로 활성화합니다.

### 추가된 스킬: `dev-stack-java`
- **§1 Spring Boot Idioms** — Constructor injection, @Transactional(readOnly=true), @ConfigurationProperties, 스테레오타입 구분
- **§2 JPA** — LAZY 로딩 기본 + fetch join, Rich Domain Model, Auditing, Soft Delete
- **§3 Exception & Response** — @RestControllerAdvice 전역 처리, ErrorResponse 통일 형식, HTTP 상태 코드 매핑

### 활성화 방법
프로젝트 CLAUDE.md에 한 줄 추가:
```
execute 실행 시 `dev-stack-java` 스킬을 로드하고 Java/Spring Boot 관용구를 구현에 적용한다.
```

### 버전
plugin.json + marketplace.json: `0.9.0` → `0.10.0` (MINOR bump, 스킬 추가)

## 테스트

- [ ] `dev-stack-java` 스킬 단독 호출 시 세 섹션 정상 로드 확인
- [ ] Java 프로젝트 CLAUDE.md에 선언 후 execute 시 참조 확인

Closes #52