### PR TITLE
feat: execute 스킬에 프로젝트 스택 자동 감지 추가

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "karpathy-guidelines와 issue-driven development가 구조적으로 통합된 커스텀 개발 워크플로우 하네스",
-    "version": "0.10.0"
+    "version": "0.11.0"
   },
   "plugins": [
     {
       "name": "sr-harness",
       "source": "./",
       "description": "karpathy-guidelines와 issue-driven development가 구조적으로 통합된 커스텀 개발 워크플로우 하네스",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "author": {
         "name": "SeokRae",
         "email": "kslbsh@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sr-harness",
   "description": "karpathy-guidelines와 issue-driven development가 구조적으로 통합된 커스텀 개발 워크플로우 하네스",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "author": {
     "name": "SeokRae",
     "email": "kslbsh@gmail.com"

--- a/README.ko.md
+++ b/README.ko.md
@@ -117,17 +117,15 @@ start
 | `debug` | 진단 우선 디버깅 |
 | `dev-coding-principles` | 코딩 품질 체크리스트 — 네이밍·예외처리·테스트 |
 | `dev-architecture` | 아키텍처 체크리스트 — Hexagonal·레이어 분리·패키지 구조 |
-| `dev-stack-java` | Java/Spring Boot 관용구 — Spring·JPA·예외처리 (프로젝트별 활성화) |
+| `dev-stack-java` | Java/Spring Boot 관용구 — Spring·JPA·예외처리 (자동 감지) |
 
-### 스택별 스킬 (프로젝트 CLAUDE.md 선언)
+### 스택 자동 감지
 
-`dev-stack-java`는 execute에 전역으로 연결되지 않는다 — 프로젝트 `CLAUDE.md`에 한 줄을 추가하여 활성화한다:
+`execute`가 프로젝트 스택을 자동 감지하여 해당 스킬을 로드한다:
 
-```markdown
-execute 실행 시 `dev-stack-java` 스킬을 로드하고 Java/Spring Boot 관용구를 구현에 적용한다.
-```
-
-execute 체크포인트를 가볍게 유지하면서 프로젝트별 스택 커스터마이징이 가능하다.
+| 감지 파일 | 로드되는 스킬 |
+|-----------|-------------|
+| `build.gradle` 또는 `pom.xml` | `dev-stack-java` |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -133,17 +133,15 @@ start
 | `pause` | Suspend session · hand off to next session |
 | `dev-coding-principles` | Coding quality checklist — Naming, Exception Handling, Test |
 | `dev-architecture` | Architecture checklist — Hexagonal, Layer Separation, Package Structure |
-| `dev-stack-java` | Java/Spring Boot idioms — Spring, JPA, Exception & Response (project-scoped) |
+| `dev-stack-java` | Java/Spring Boot idioms — Spring, JPA, Exception & Response (auto-detected) |
 
-### Stack-specific skills (project CLAUDE.md)
+### Stack auto-detection
 
-`dev-stack-java` is not wired into `execute` globally — activate it per project by adding one line to the project `CLAUDE.md`:
+`execute` automatically detects the project stack and loads the matching skill:
 
-```markdown
-execute 실행 시 `dev-stack-java` 스킬을 로드하고 Java/Spring Boot 관용구를 구현에 적용한다.
-```
-
-This keeps the execute checkpoint lean while allowing per-project stack customization.
+| Indicator file | Skill loaded |
+|----------------|-------------|
+| `build.gradle` or `pom.xml` | `dev-stack-java` |
 
 ---
 

--- a/skills/execute/SKILL.md
+++ b/skills/execute/SKILL.md
@@ -44,6 +44,12 @@ git branch --show-current  # feature/* 여야 함, main이면 안 됨
 코드 프로젝트인 경우 → `dev-coding-principles` 스킬을 로드하고 원칙(§1 Naming, §2 Exception Handling, §3 Test)을 구현에 적용한다.
 코드 프로젝트인 경우 → `dev-architecture` 스킬을 로드하고 아키텍처 원칙(§1 Hexagonal, §2 Layer Separation, §3 Package Structure)을 구현에 적용한다.
 
+코드 프로젝트인 경우 → 프로젝트 스택을 자동 감지한다:
+```bash
+ls build.gradle pom.xml 2>/dev/null
+```
+- `build.gradle` 또는 `pom.xml` 존재 → `dev-stack-java` 스킬을 로드하고 Spring Boot 관용구(§1 Spring Boot, §2 JPA, §3 Exception & Response)를 구현에 적용한다.
+
 ## 실행 모드 판단
 
 플랜 파일(`.claude/session-plan.md`)을 읽어 제외 조건을 체크한다.


### PR DESCRIPTION
## 변경 내용

`execute` 체크포인트에 프로젝트 스택 자동 감지 로직 추가.

- `build.gradle` 또는 `pom.xml` 감지 시 → `dev-stack-java` 스킬 자동 로드
- 기존 CLAUDE.md 수동 선언 방식 제거
- README.md / README.ko.md 스택 자동 감지 섹션으로 업데이트
- 버전 0.10.0 → 0.11.0 bump

## 테스트

- [ ] execute SKILL.md에 스택 감지 블록 추가 확인
- [ ] plugin.json / marketplace.json 버전 0.11.0 확인

Closes #54