### PR TITLE
feat: plan·execute·verify 스킬에 자기보고 단계 추가

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "karpathy-guidelines와 issue-driven development가 구조적으로 통합된 커스텀 개발 워크플로우 하네스",
-    "version": "0.12.0"
+    "version": "0.12.1"
   },
   "plugins": [
     {
       "name": "sr-harness",
       "source": "./",
       "description": "karpathy-guidelines와 issue-driven development가 구조적으로 통합된 커스텀 개발 워크플로우 하네스",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "author": {
         "name": "SeokRae",
         "email": "kslbsh@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sr-harness",
   "description": "karpathy-guidelines와 issue-driven development가 구조적으로 통합된 커스텀 개발 워크플로우 하네스",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "author": {
     "name": "SeokRae",
     "email": "kslbsh@gmail.com"

--- a/skills/execute/SKILL.md
+++ b/skills/execute/SKILL.md
@@ -222,3 +222,13 @@ git commit -m "{type}: {설명} (#N)"
 - 테스트 실패 / 예상 밖 에러 → `debug` 전환
 - 범위 밖 작업 발견 → session-plan.md Deviations 기록, 현재 작업 계속
 - 서브에이전트 BLOCKED → 원인 분석: 컨텍스트 보강 재시도 / 모델 업그레이드 / 태스크 분할 / 사용자 에스컬레이션
+
+## 자기보고 (evolution_log)
+
+execute 완료(또는 실패) 시 아래 명령어를 실행한다.
+`team_mode`·`error_occurred`·`outcome`은 실제 실행 결과 기준으로 채운다.
+
+```bash
+python3 ~/.claude/hooks/evolution-log-skill.py \
+  '{"skill":"sr-harness:execute","outcome":"{completed|partial|failed}","metrics":{"team_mode":{true|false},"error_occurred":{true|false}}}'
+```

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -76,3 +76,19 @@ scope:
   - {단계 목록}
 ---
 ```
+
+## 자기보고 (evolution_log)
+
+계획 확정 후 아래 명령어를 실행해 메트릭을 기록한다.
+`step_count`와 `has_verify_criteria`는 실제 작성한 계획 기준으로 채운다.
+
+```bash
+python3 ~/.claude/hooks/evolution-log-skill.py \
+  '{"skill":"sr-harness:plan","outcome":"completed","metrics":{"step_count":{N},"has_verify_criteria":{true|false}}}'
+```
+
+계획이 중단되거나 사용자가 승인하지 않은 경우:
+```bash
+python3 ~/.claude/hooks/evolution-log-skill.py \
+  '{"skill":"sr-harness:plan","outcome":"abandoned","metrics":{"step_count":{N},"has_verify_criteria":{true|false}}}'
+```

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -53,3 +53,13 @@ git diff origin/main --name-only
 
 - 테스트 실패 상태에서 submit 진행 금지
 - 변경 파일 목록 확인 없이 submit 진행 금지
+
+## 자기보고 (evolution_log)
+
+verify 결과 확정 시 아래 명령어를 실행한다.
+`items_checked`는 실제 검증한 항목 수, `outcome`은 pass/fail.
+
+```bash
+python3 ~/.claude/hooks/evolution-log-skill.py \
+  '{"skill":"sr-harness:verify","outcome":"{pass|fail}","metrics":{"items_checked":{N}}}'
+```


### PR DESCRIPTION
## 변경 사항

- `skills/plan/SKILL.md` — 자기보고 단계 추가
- `skills/execute/SKILL.md` — 자기보고 단계 추가
- `skills/verify/SKILL.md` — 자기보고 단계 추가

## 자기보고 형식

각 스킬 완료 시 Claude가 직접 실행:
```bash
python3 ~/.claude/hooks/evolution-log-skill.py '<json>'
```

| 스킬 | 기록 메트릭 |
|---|---|
| plan | step_count, has_verify_criteria, outcome |
| execute | team_mode, error_occurred, outcome |
| verify | items_checked, outcome |

## 의존

`~/.claude/hooks/evolution-log-skill.py` 별도 배포 (로컬 훅, 플러그인 외부)

## 버전

`0.12.0` → `0.12.1` (patch)

Closes #60