### PR TITLE
feat: execute 팀모드를 tmux + claude CLI + Monitor 방식으로 재구현

### DIFF
--- a/scripts/sr-team-launch.sh
+++ b/scripts/sr-team-launch.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# sr-team-launch.sh: tmux 기반 팀모드 런처
+# 사용법: sr-team-launch.sh <job_dir> <total> <worktree_1> [<worktree_2> ...]
+#
+# job_dir: task-N.md / result-N.md / N.status 파일이 위치할 디렉토리
+# total:   에이전트 수
+# worktree_N: 각 에이전트의 작업 디렉토리 (git worktree 경로)
+
+set -euo pipefail
+
+if [ $# -lt 3 ]; then
+  echo "사용법: $0 <job_dir> <total> <worktree_1> [<worktree_2> ...]" >&2
+  exit 1
+fi
+
+JOB_DIR="$1"
+TOTAL="$2"
+shift 2
+WORKTREES=("$@")
+
+if [ "${#WORKTREES[@]}" -lt "$TOTAL" ]; then
+  echo "오류: worktree 경로 수(${#WORKTREES[@]})가 total($TOTAL)보다 적습니다." >&2
+  exit 1
+fi
+
+SESSION="sr-team"
+
+# 기존 세션 정리
+tmux kill-session -t "$SESSION" 2>/dev/null && echo "기존 sr-team 세션 종료" || true
+
+# 상태판 윈도우로 세션 시작
+tmux new-session -d -s "$SESSION" -n "status"
+
+STATUS_SCRIPT="$(cat <<'WATCH'
+while true; do
+  clear
+  echo "=== sr-team 상태 ($(date '+%H:%M:%S')) ==="
+  echo ""
+WATCH
+)"
+for i in $(seq 1 "$TOTAL"); do
+  STATUS_SCRIPT+="  f=\"$JOB_DIR/$i.status\"; [ -f \"\$f\" ] && echo \"  agent-$i: \$(cat \"\$f\")\" || echo \"  agent-$i: RUNNING...\""$'\n'
+done
+STATUS_SCRIPT+="  sleep 3
+done"
+
+tmux send-keys -t "$SESSION:status" "bash -c '$STATUS_SCRIPT'" Enter
+
+# 각 에이전트 윈도우
+for i in $(seq 1 "$TOTAL"); do
+  WT="${WORKTREES[$((i-1))]}"
+  TASK_FILE="$JOB_DIR/task-$i.md"
+  RESULT_FILE="$JOB_DIR/result-$i.md"
+  STATUS_FILE="$JOB_DIR/$i.status"
+
+  tmux new-window -t "$SESSION" -n "agent-$i"
+
+  AGENT_CMD="set -o pipefail
+echo '[agent-$i] 시작: \$(date)'
+cd '$WT'
+claude -p --permission-mode bypassPermissions \"\$(cat '$TASK_FILE')\" 2>&1 | tee '$RESULT_FILE'
+EXIT=\$?
+if [ \$EXIT -eq 0 ]; then
+  echo 'DONE' > '$STATUS_FILE'
+else
+  echo 'ERROR' > '$STATUS_FILE'
+fi
+echo '[agent-$i] 완료: '\$(cat '$STATUS_FILE')' (exit: '\$EXIT')'"
+
+  tmux send-keys -t "$SESSION:agent-$i" "bash -c \"$AGENT_CMD\"" Enter
+done
+
+# 상태판으로 포커스
+tmux select-window -t "$SESSION:status"
+
+echo ""
+echo "✅ sr-team 세션 시작됨"
+echo "👀 실시간 확인: tmux attach -t sr-team"
+echo "📁 job_dir: $JOB_DIR"
+echo "🤖 에이전트 수: $TOTAL"
+echo ""
+echo "완료 감시: bash sr-team-watch.sh '$JOB_DIR' '$TOTAL'"

--- a/scripts/sr-team-watch.sh
+++ b/scripts/sr-team-watch.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# sr-team-watch.sh: 팀모드 완료 감시
+# 사용법: sr-team-watch.sh <job_dir> <total>
+#
+# 모든 에이전트 완료 시 stdout에 출력:
+#   ALL_DONE             — 전원 성공
+#   DONE_WITH_ERRORS:N   — N개 에이전트 실패
+
+set -euo pipefail
+
+if [ $# -ne 2 ]; then
+  echo "사용법: $0 <job_dir> <total>" >&2
+  exit 1
+fi
+
+JOB_DIR="$1"
+TOTAL="$2"
+
+while true; do
+  DONE=0
+  ERRORS=0
+
+  for i in $(seq 1 "$TOTAL"); do
+    STATUS_FILE="$JOB_DIR/$i.status"
+    if [ -f "$STATUS_FILE" ]; then
+      DONE=$((DONE + 1))
+      STATUS=$(cat "$STATUS_FILE")
+      [ "$STATUS" = "ERROR" ] && ERRORS=$((ERRORS + 1))
+    fi
+  done
+
+  if [ "$DONE" -eq "$TOTAL" ]; then
+    if [ "$ERRORS" -eq 0 ]; then
+      echo "ALL_DONE"
+    else
+      echo "DONE_WITH_ERRORS:$ERRORS"
+    fi
+    exit 0
+  fi
+
+  sleep 10
+done

--- a/skills/execute/SKILL.md
+++ b/skills/execute/SKILL.md
@@ -109,44 +109,78 @@ git commit -m "{type}: {설명} (#N)"
 
 ## 팀모드 실행 모드
 
-제외 조건이 없을 때 기본으로 시도하는 병렬 dispatch 모드.
+제외 조건이 없을 때 기본으로 시도하는 병렬 실행 모드.
+각 에이전트는 별도 tmux pane에서 `claude -p` CLI로 실행되어 진행 상황을 실시간으로 확인할 수 있다.
 
 ### 원칙
 
-- 독립 태스크를 여러 에이전트에 동시에 dispatch
-- 각 에이전트는 커밋 전 `git pull --rebase origin {브랜치명}` 실행 — 충돌 방지 필수
-- 모든 에이전트 완료 후 2단계 리뷰(스펙 → 코드 품질) 통과 시 다음 단계 진행
+- 독립 태스크를 각자의 tmux pane에서 `claude -p --permission-mode bypassPermissions`로 병렬 실행
+- 각 에이전트는 지정된 worktree에서 task 파일을 읽어 실행하고 결과를 result 파일에 기록
+- Monitor 툴로 완료를 자동 감지해 리뷰 단계 진행 — 사용자가 직접 트리거하지 않아도 됨
+- 커밋 전 `git pull --rebase origin {브랜치명}` 필수 — 병렬 작업 충돌 방지
 
 ### 실행 흐름
 
 ```
 1. 플랜 파일에서 독립 태스크 목록 추출
-2. 모든 독립 태스크를 Agent 병렬 dispatch (단일 메시지에 복수 Agent 호출)
-     컨텍스트: 태스크 전문 + 관련 파일 경로 + 브랜치명 + worktree 경로
-     서브에이전트 결과: DONE / DONE_WITH_CONCERNS / NEEDS_CONTEXT / BLOCKED
-3. 모든 에이전트 완료 후 결과 취합
-4. [태스크 N] 스펙 리뷰 확인
-     ❌ 불일치 → 해당 에이전트만 재dispatch → 재리뷰
-     ✅ 통과 →
-5. [태스크 N] 코드 품질 리뷰 확인
-     ❌ 이슈 → 해당 에이전트만 재dispatch → 재리뷰
-     ✅ 통과 → 다음 태스크
+2. 태스크별 task-N.md 작성 → {job_dir}/task-N.md
+     (내용: 태스크 전문 + worktree 경로 + 브랜치명 + 커밋 규칙)
+3. Bash: sr-team-launch.sh {job_dir} {total} {worktree_1} ... {worktree_N}
+     → 사용자에게 안내: "tmux attach -t sr-team 으로 진행 상황 확인 가능"
+4. Monitor: sr-team-watch.sh {job_dir} {total}
+     → ALL_DONE            → 5단계로 진행
+     → DONE_WITH_ERRORS:N  → {job_dir}/result-N.md 읽어 원인 파악 후 해당 에이전트만 재실행
+5. result-N.md 읽어서 2단계 리뷰 진행
+     [태스크 N] 스펙 리뷰: 스펙 불일치 → 해당 에이전트만 재실행 → 재리뷰
+     [태스크 N] 코드 품질 리뷰: 이슈 → 해당 에이전트만 재실행 → 재리뷰
 6. 모든 태스크 리뷰 통과 → verify → submit
 ```
 
-### 서브에이전트 상태 처리
+### task-N.md 작성 형식
+
+```markdown
+# Task {N}: {제목}
+
+## 작업 위치
+- worktree: {worktree_path}
+- branch: {branch_name}
+- issue: #{issue_number}
+
+## 작업 내용
+{태스크 전문}
+
+## 관련 파일
+{관련 파일 경로 목록}
+
+## 커밋 규칙
+- `git pull --rebase origin {브랜치명}` 후 커밋
+- 커밋 메시지: `{type}: {설명} (#{issue_number})`
+- `git add .` 금지 — 관련 파일만 명시 지정
+- 구현 완료 후 반드시 커밋까지 완료하고 종료
+```
+
+### 스크립트 실행
+
+```bash
+# 런처 — tmux 세션 생성 + 에이전트 실행
+LAUNCH=$(find ~/.claude/plugins/cache/sr-harness -name "sr-team-launch.sh" | head -1)
+bash "$LAUNCH" {job_dir} {total} {worktree_1} [{worktree_2} ...]
+
+# 감시 — Monitor 툴로 실행 (완료 시 ALL_DONE 또는 DONE_WITH_ERRORS:N 출력)
+WATCH=$(find ~/.claude/plugins/cache/sr-harness -name "sr-team-watch.sh" | head -1)
+# → Monitor 툴에 "bash $WATCH {job_dir} {total}" 전달
+```
+
+### 완료 상태 처리
 
 | 상태 | 처리 |
 |------|------|
-| `DONE` | 스펙 리뷰로 진행 |
-| `DONE_WITH_CONCERNS` | concerns 확인 후 스펙 리뷰 진행 |
-| `NEEDS_CONTEXT` | 누락 컨텍스트 제공 후 해당 에이전트만 재dispatch |
-| `BLOCKED` | 원인 파악 → 컨텍스트 보강 재시도 / 더 강한 모델 / 태스크 분할 / 사용자 에스컬레이션 |
+| `ALL_DONE` | 스펙 리뷰로 진행 |
+| `DONE_WITH_ERRORS:N` | result-N.md 확인 후 해당 태스크만 재실행 |
 
-### 충돌 방지 규칙 (서브에이전트에게 명시 전달)
+### 충돌 방지 규칙 (task-N.md에 명시 전달)
 
-- 코드 프로젝트: 모든 파일 수정은 반드시 전달받은 worktree 경로 내에서 수행 — main 워크트리 파일 직접 수정 금지
-- Vault 프로젝트: feature 브랜치에서 직접 수정 (worktree 없음)
+- 모든 파일 수정은 반드시 지정된 worktree 경로 내에서 수행 — main 워크트리 파일 직접 수정 금지
 - `git add .` 사용 금지 — 태스크 관련 파일만 명시적으로 지정
 - **커밋 전 `git pull --rebase origin {브랜치명}` 필수** — 병렬 작업 충돌 방지
 - 모든 커밋에 이슈 번호 포함: `feat: 설명 (#이슈번호)`


### PR DESCRIPTION
## 변경 내용

기존 팀모드는 `Agent` 툴로 병렬 서브에이전트를 dispatch하는 방식이라 진행 상황을 전혀 볼 수 없었다.
이번 변경으로 각 에이전트가 별도 tmux pane에서 실행되어 실시간 모니터링이 가능해졌다.

### 추가된 스크립트

- `scripts/sr-team-launch.sh`: tmux 세션 'sr-team' 생성 + N개 pane에서 `claude -p --permission-mode bypassPermissions` 병렬 실행. 각 pane 완료 시 `N.status` 파일에 DONE/ERROR 기록
- `scripts/sr-team-watch.sh`: 모든 `.status` 파일 완료를 폴링 감지. Monitor 툴로 연결해 `ALL_DONE` 또는 `DONE_WITH_ERRORS:N` 수신 시 자동으로 리뷰 단계 진행

### execute SKILL.md 팀모드 섹션 변경

| 항목 | 이전 | 이후 |
|------|------|------|
| 실행 방식 | `Agent` 툴 병렬 dispatch | tmux pane + `claude -p` |
| 진행 상황 | 불투명 (블랙박스) | `tmux attach -t sr-team` 으로 실시간 확인 |
| 완료 감지 | Agent 결과 반환 대기 | Monitor 툴 + `sr-team-watch.sh` |
| 에러 처리 | BLOCKED 상태 처리 | `DONE_WITH_ERRORS:N` + result-N.md 확인 |

## 테스트

- [x] `bash -n` 문법 검증 통과
- [x] `sr-team-watch.sh` — DONE × 2 → ALL_DONE 출력 확인
- [x] `sr-team-watch.sh` — DONE + ERROR → DONE_WITH_ERRORS:1 출력 확인

Closes #62