### PR TITLE
feat: goal 스킬 추가 + verify completion audit 통합 (v0.13.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sr-harness",
   "description": "karpathy-guidelines와 issue-driven development가 구조적으로 통합된 커스텀 개발 워크플로우 하네스",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "author": {
     "name": "SeokRae",
     "email": "kslbsh@gmail.com"
@@ -28,6 +28,7 @@
     "./skills/abort",
     "./skills/pause",
     "./skills/ralph",
+    "./skills/goal",
     "./skills/dev-coding-principles",
     "./skills/dev-architecture",
     "./skills/dev-stack-java",

--- a/hooks/stop-hook.sh
+++ b/hooks/stop-hook.sh
@@ -1,21 +1,103 @@
 #!/bin/bash
 
-# Ralph Loop Stop Hook
-# Prevents session exit when a ralph-loop is active
-# Feeds Claude's output back as input to continue the loop
+# Loop Stop Hook
+# Handles both ralph-loop and goal-loop: prevents session exit while active,
+# feeds Claude's output back as input to continue the loop.
 
 set -euo pipefail
 
 # Read hook input from stdin (advanced stop hook API)
 HOOK_INPUT=$(cat)
 
-# Check if ralph-loop is active
 RALPH_STATE_FILE=".claude/ralph-loop.local.md"
+GOAL_STATE_FILE=".claude/goal-state.json"
 
-if [[ ! -f "$RALPH_STATE_FILE" ]]; then
-  # No active loop - allow exit
+# No active loop - allow exit
+if [[ ! -f "$RALPH_STATE_FILE" ]] && [[ ! -f "$GOAL_STATE_FILE" ]]; then
   exit 0
 fi
+
+# ── Goal loop ─────────────────────────────────────────────
+# Processed first so ralph (if also present) takes precedence below
+if [[ ! -f "$RALPH_STATE_FILE" ]] && [[ -f "$GOAL_STATE_FILE" ]]; then
+
+  GOAL_STATUS=$(jq -r '.status' "$GOAL_STATE_FILE" 2>/dev/null || echo "unknown")
+  if [[ "$GOAL_STATUS" != "active" ]]; then
+    exit 0
+  fi
+
+  # Session isolation
+  GOAL_SESSION=$(jq -r '.session_id // ""' "$GOAL_STATE_FILE")
+  HOOK_SESSION=$(echo "$HOOK_INPUT" | jq -r '.session_id // ""')
+  if [[ -n "$GOAL_SESSION" ]] && [[ "$GOAL_SESSION" != "$HOOK_SESSION" ]]; then
+    exit 0
+  fi
+
+  GOAL_ITER=$(jq -r '.iteration' "$GOAL_STATE_FILE")
+  GOAL_MAX=$(jq -r '.max_iterations' "$GOAL_STATE_FILE")
+  GOAL_TEXT=$(jq -r '.goal' "$GOAL_STATE_FILE")
+
+  if [[ ! "$GOAL_ITER" =~ ^[0-9]+$ ]] || [[ ! "$GOAL_MAX" =~ ^[0-9]+$ ]]; then
+    echo "⚠️  Goal loop: goal-state.json 손상됨 — 루프 중단" >&2
+    bash "${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-goal.sh" 2>/dev/null || true
+    exit 0
+  fi
+
+  if [[ $GOAL_MAX -gt 0 ]] && [[ $GOAL_ITER -ge $GOAL_MAX ]]; then
+    echo "🛑 Goal loop: Max iterations ($GOAL_MAX) reached."
+    bash "${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-goal.sh" 2>/dev/null || true
+    exit 0
+  fi
+
+  TRANSCRIPT_PATH=$(echo "$HOOK_INPUT" | jq -r '.transcript_path')
+  if [[ ! -f "$TRANSCRIPT_PATH" ]] || ! grep -q '"role":"assistant"' "$TRANSCRIPT_PATH"; then
+    exit 0
+  fi
+
+  LAST_LINES=$(grep '"role":"assistant"' "$TRANSCRIPT_PATH" | tail -n 100)
+  set +e
+  LAST_OUTPUT=$(echo "$LAST_LINES" | jq -rs '
+    map(.message.content[]? | select(.type == "text") | .text) | last // ""
+  ' 2>&1)
+  JQ_EXIT=$?
+  set -e
+
+  if [[ $JQ_EXIT -ne 0 ]]; then
+    exit 0
+  fi
+
+  PROMISE_TEXT=$(echo "$LAST_OUTPUT" | perl -0777 -pe 's/.*?<promise>(.*?)<\/promise>.*/$1/s; s/^\s+|\s+$//g; s/\s+/ /g' 2>/dev/null || echo "")
+  if [[ -n "$PROMISE_TEXT" ]] && [[ "$PROMISE_TEXT" = "GOAL_ACHIEVED" ]]; then
+    echo "✅ Goal loop: <promise>GOAL_ACHIEVED</promise> 감지 — 루프 종료"
+    bash "${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-goal.sh" 2>/dev/null || true
+    exit 0
+  fi
+
+  # Not complete — increment iteration and re-inject goal prompt
+  NEXT_ITER=$((GOAL_ITER + 1))
+  TEMP_FILE="${GOAL_STATE_FILE}.tmp.$$"
+  jq --argjson n "$NEXT_ITER" '.iteration = $n' "$GOAL_STATE_FILE" > "$TEMP_FILE"
+  mv "$TEMP_FILE" "$GOAL_STATE_FILE"
+
+  GOAL_PROMPT="🎯 Goal: ${GOAL_TEXT}
+
+이 목표가 달성될 때까지 계속 작업한다.
+완료 조건에 도달하면 반드시 <promise>GOAL_ACHIEVED</promise> 를 출력한다.
+(완료 조건: 목표에 기술된 상태가 실제로 달성된 것을 확인한 경우에만. 거짓으로 탈출 금지)"
+
+  jq -n \
+    --arg prompt "$GOAL_PROMPT" \
+    --arg msg "🔄 Goal iteration $NEXT_ITER / $GOAL_MAX | 완료: <promise>GOAL_ACHIEVED</promise>" \
+    '{
+      "decision": "block",
+      "reason": $prompt,
+      "systemMessage": $msg
+    }'
+  exit 0
+fi
+
+# ── Ralph loop ────────────────────────────────────────────
+# Check if ralph-loop is active
 
 # Restore bypass permissions and remove state file on any termination path.
 # Called instead of bare `rm "$RALPH_STATE_FILE"` to avoid leaving

--- a/scripts/cleanup-goal.sh
+++ b/scripts/cleanup-goal.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# harness-goal cleanup script
+# .claude/goal-state.json 제거
+
+set -euo pipefail
+
+STATE_FILE=".claude/goal-state.json"
+
+if [[ -f "$STATE_FILE" ]]; then
+  GOAL=$(jq -r '.goal' "$STATE_FILE" 2>/dev/null || echo "(읽기 실패)")
+  ITER=$(jq -r '.iteration' "$STATE_FILE" 2>/dev/null || echo "?")
+  rm -f "$STATE_FILE"
+  echo "🧹 goal 상태 파일 제거 (iteration: ${ITER})"
+  echo "   목표: ${GOAL}"
+else
+  echo "ℹ️  goal 상태 파일 없음 (이미 제거됨)"
+fi
+
+echo "✅ harness-goal cleanup 완료"

--- a/scripts/setup-goal.sh
+++ b/scripts/setup-goal.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# harness-goal setup script
+# goal 텍스트를 받아 .claude/goal-state.json 생성
+
+set -euo pipefail
+
+STATE_FILE=".claude/goal-state.json"
+
+if [[ $# -lt 1 ]] || [[ -z "$1" ]]; then
+  echo "❌ 사용법: setup-goal.sh \"목표 텍스트\"" >&2
+  exit 1
+fi
+
+GOAL_TEXT="$1"
+
+if [[ -f "$STATE_FILE" ]]; then
+  STATUS=$(jq -r '.status' "$STATE_FILE" 2>/dev/null || echo "unknown")
+  echo "⚠️  활성 goal이 이미 존재합니다 (status: ${STATUS})" >&2
+  echo "   취소하려면: bash \"\${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-goal.sh\"" >&2
+  exit 1
+fi
+
+mkdir -p .claude
+
+SESSION_ID="${CLAUDE_CODE_SESSION_ID:-}"
+STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+jq -n \
+  --arg goal "$GOAL_TEXT" \
+  --arg session_id "$SESSION_ID" \
+  --arg started_at "$STARTED_AT" \
+  '{
+    goal: $goal,
+    status: "active",
+    session_id: $session_id,
+    started_at: $started_at,
+    iteration: 1,
+    max_iterations: 20
+  }' > "$STATE_FILE"
+
+echo ""
+echo "🎯 goal 설정 완료!"
+echo ""
+echo "   목표: ${GOAL_TEXT}"
+echo "   session_id: ${SESSION_ID:-"(없음)"}"
+echo "   max_iterations: 20"
+echo ""
+echo "Stop hook이 활성화됩니다. 완료 조건: <promise>GOAL_ACHIEVED</promise>"
+echo "일시 중단: /goal pause   |   강제 종료: bash \"\${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-goal.sh\""

--- a/skills/goal/SKILL.md
+++ b/skills/goal/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: goal
+description: plan/worktree 없이 자율 실행. /goal "목표" → Stop hook 기반으로 목표 달성까지 반복. pause/resume/clear/status 지원. Keywords: goal, 목표, 자율 실행, 자동 반복, ralph 대안
+allowed-tools: ["Bash(${CLAUDE_PLUGIN_ROOT}/scripts/setup-goal.sh:*)", "Bash(${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-goal.sh:*)"]
+---
+
+# sr-harness:goal
+
+목표 텍스트 하나로 자율 실행을 시작한다.
+plan / worktree 없이도 동작하는 가벼운 자율 실행 모드.
+
+## 명령 형식
+
+| 명령 | 동작 |
+|------|------|
+| `/goal "목표 텍스트"` | goal 설정 + 즉시 실행 시작 |
+| `/goal status` | 현재 goal 상태 출력 |
+| `/goal pause` | 일시 중단 (상태 보존) |
+| `/goal resume` | 재개 |
+| `/goal clear` | 강제 종료 + 상태 파일 제거 |
+
+---
+
+## `/goal "목표 텍스트"`
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/setup-goal.sh" "목표 텍스트"
+```
+
+setup 완료 즉시 목표 달성을 향한 작업을 시작한다.
+Stop hook이 `<promise>GOAL_ACHIEVED</promise>` 를 감지할 때까지 반복된다.
+
+### 실행 원칙
+
+- plan / worktree 없이 시작 가능
+- 목표가 달성됐다고 판단하면 반드시 `<promise>GOAL_ACHIEVED</promise>` 출력
+- 달성되지 않은 상태에서 promise 출력 금지
+- 각 반복에서 `verify` 스킬의 completion audit 기준으로 달성 여부 판단
+
+### 완료 처리
+
+목표 달성 확인 후:
+1. `<promise>GOAL_ACHIEVED</promise>` 출력
+2. 다음 단계 안내: `/submit` 또는 `/verify`
+
+---
+
+## `/goal status`
+
+`.claude/goal-state.json` 존재 여부 확인 후 출력:
+
+```bash
+# 활성 goal이 있을 때
+cat .claude/goal-state.json
+```
+
+없으면: "활성 goal 없음"
+
+출력 형식:
+```
+🎯 현재 Goal
+   목표: {goal 텍스트}
+   상태: {active|paused}
+   반복: {iteration} / {max_iterations}
+   시작: {started_at}
+```
+
+---
+
+## `/goal pause`
+
+```bash
+# goal-state.json의 status를 paused로 변경
+jq '.status = "paused"' .claude/goal-state.json > .claude/goal-state.json.tmp && \
+  mv .claude/goal-state.json.tmp .claude/goal-state.json
+echo "⏸ goal 일시 중단. 재개: /goal resume"
+```
+
+---
+
+## `/goal resume`
+
+```bash
+# goal-state.json의 status를 active로 변경
+jq '.status = "active"' .claude/goal-state.json > .claude/goal-state.json.tmp && \
+  mv .claude/goal-state.json.tmp .claude/goal-state.json
+echo "▶️ goal 재개. Stop hook이 다시 활성화됩니다."
+```
+
+현재 세션 session_id로 갱신도 함께 수행:
+```bash
+jq --arg sid "${CLAUDE_CODE_SESSION_ID:-}" '.status = "active" | .session_id = $sid' \
+  .claude/goal-state.json > .claude/goal-state.json.tmp && \
+  mv .claude/goal-state.json.tmp .claude/goal-state.json
+```
+
+---
+
+## `/goal clear`
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-goal.sh"
+```
+
+---
+
+## ralph와의 차이
+
+| | ralph | goal |
+|---|---|---|
+| 시작 조건 | session-plan.md + worktree 필수 | 목표 텍스트만 필요 |
+| 권한 변경 | bypass 권한 추가 | 변경 없음 |
+| 종료 조건 | verify 통과 | 목표 달성 선언 |
+| 재개 | 불가 | pause/resume 지원 |
+
+ralph가 이미 활성 상태이면 goal 루프는 동작하지 않는다 (ralph 우선).
+
+## 금지 사항
+
+- 목표 미달성 상태에서 `<promise>GOAL_ACHIEVED</promise>` 출력 금지
+- 활성 goal이 있는 상태에서 중복 `/goal "..."` 시작 금지 → `/goal status` 로 확인 후 `/goal clear` 먼저

--- a/skills/start/SKILL.md
+++ b/skills/start/SKILL.md
@@ -13,14 +13,22 @@ description: sr-harness 세션 진입점. 모든 대화 시작 시 반드시 먼
    - 있으면: 목표와 미완료 항목 로드 → 사용자에게 한 줄로 상태 보고
    - 없으면: 작업 시작 전에 생성 (목표 + scope + tasks 포함)
 
-2. 활성 worktree 감지
+2. 활성 goal 감지
+   ```bash
+   cat .claude/goal-state.json 2>/dev/null | jq -r '.status // empty'
+   ```
+   - `active`: "진행 중인 goal이 있습니다: {goal 텍스트}" → `/goal resume` 또는 `/goal clear` 안내
+   - `paused`: "일시 중단된 goal이 있습니다: {goal 텍스트}" → `/goal resume` 으로 재개 안내
+   - 없으면 → 다음 단계
+
+3. 활성 worktree 감지
    ```bash
    git worktree list
    ```
    - `.claude/worktrees/`에 활성 worktree가 있으면 → 해당 작업 재개 안내
    - 없으면 → 새 작업 시작
 
-3. 아래 라우팅 표로 적절한 스킬 호출
+4. 아래 라우팅 표로 적절한 스킬 호출
 
 ## 라우팅 표
 
@@ -31,6 +39,7 @@ description: sr-harness 세션 진입점. 모든 대화 시작 시 반드시 먼
 | Issue 생성, 브랜치 생성 | `issue` |
 | 코드 작성, 기능 구현, PR 작업 | `execute` |
 | 자동으로 구현, ralph 모드, bypass로 실행 | `ralph` |
+| 목표 기반 자율 실행, plan 없이 바로 시작 | `goal` |
 | 버그, 테스트 실패, 에러 | `debug` |
 | PR 올리기, push, 리뷰 요청 | `submit` |
 | 머지, 마무리, 브랜치 정리 | `finish` |
@@ -67,4 +76,5 @@ brainstorm → plan → issue → execute → verify → submit → [사용자 �
                                         ↑ debug ↓
                                     review (리뷰 피드백 반영 시)
                                또는 ralph (bypass 자동화 모드)
+                               또는 goal  (목표 기반 가벼운 자율 실행)
 ```

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -32,12 +32,27 @@ git diff origin/main --name-only
 {테스트 명령어 실행}
 ```
 
-### 4. 검증 결과 보고
+### 4. Completion Audit (goal 활성 시만 실행)
+
+```bash
+cat .claude/goal-state.json 2>/dev/null | jq -r 'select(.status == "active") | .goal'
+```
+
+`.claude/goal-state.json`이 존재하고 `status == "active"`이면:
+- goal 텍스트를 읽어 다음 질문에 답한다:
+  **"현재 코드/파일 상태가 goal에 기술된 목표를 완전히 달성했는가?"**
+  - YES → `<promise>GOAL_ACHIEVED</promise>` 출력 후 아래 보고에 포함
+  - NO → 미달성 이유 명시 + execute 재진입 (submit 금지)
+
+파일이 없거나 status != "active"이면 이 단계를 건너뛴다.
+
+### 5. 검증 결과 보고
 ```
 [verify 결과]
 ✅ 미커밋 변경사항 없음
 ✅ 변경 파일: {N}개 (목록 표시)
 ✅ 테스트: {명령어} → {통과/실패}
+✅ Completion Audit: {goal 달성 확인 / 해당 없음}
 ```
 
 ## 결과에 따른 전환
@@ -46,6 +61,7 @@ git diff origin/main --name-only
 |------|----------|
 | 모든 항목 통과 | `submit` 호출 |
 | 테스트 실패 | `debug` 전환 후 `execute` 재진입 |
+| Completion Audit 미달성 | execute 재진입 (submit 금지) |
 | 의도치 않은 파일 변경 | 사용자 확인 후 수정 → 재검증 |
 | 미커밋 변경 있음 | 커밋 처리 후 재검증 |
 


### PR DESCRIPTION
## 변경 내용

### 배경
ralph는 plan + worktree가 모두 갖춰진 상태에서만 동작하는 반면, Codex의 `/goal` 방식은 목표 텍스트 하나로 Stop hook 기반 자율 실행을 시작할 수 있습니다. 이 패턴을 sr-harness에 도입합니다.

### 신규: `goal` 스킬
- `/goal "목표 텍스트"` → plan/worktree 없이 자율 실행 시작
- Stop hook 기반 (`<promise>GOAL_ACHIEVED</promise>` 감지 시 종료)
- `/goal pause` / `/goal resume` / `/goal clear` / `/goal status` 지원
- 상태 파일: `.claude/goal-state.json`

### 신규 스크립트
- `scripts/setup-goal.sh` — goal 상태 파일 생성 (JSON)
- `scripts/cleanup-goal.sh` — goal 상태 파일 제거

### `hooks/stop-hook.sh` 확장
- ralph 없고 goal 활성 시 goal 루프 처리
- session_id 격리, max_iterations 상한, GOAL_ACHIEVED promise 감지
- ralph가 있으면 ralph 우선 (기존 동작 유지)

### `verify` 스킬 개선
- goal 활성 시 completion audit 단계 추가
- goal 비활성 시 기존 3단계 동작 유지 (하위 호환)

### `start` 스킬 업데이트
- 세션 시작 시 goal 상태 감지 및 안내
- 라우팅 표에 goal 항목 추가

## ralph와의 차이

| | ralph | goal |
|---|---|---|
| 시작 조건 | session-plan.md + worktree 필수 | 목표 텍스트만 필요 |
| 권한 변경 | bypass 권한 추가 | 변경 없음 |
| 종료 조건 | verify 통과 | 목표 달성 선언 |
| 재개 | 불가 | pause/resume 지원 |

## 테스트

- [x] setup-goal.sh → goal-state.json 생성 확인
- [x] cleanup-goal.sh → 파일 삭제 확인
- [x] stop-hook: GOAL_ACHIEVED 감지 시 exit 0 + 상태 파일 삭제
- [x] stop-hook: 미달성 시 block JSON 반환 + iteration 증가
- [x] ralph/goal 없을 때 stop-hook exit 0 유지

Closes #66