### PR TITLE
fix: Obsidian vault 프로젝트 worktree 없이 동작 지원 (v0.14.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "karpathy-guidelines와 issue-driven development가 구조적으로 통합된 커스텀 개발 워크플로우 하네스",
-    "version": "0.13.1"
+    "version": "0.14.1"
   },
   "plugins": [
     {
       "name": "sr-harness",
       "source": "./",
       "description": "karpathy-guidelines와 issue-driven development가 구조적으로 통합된 커스텀 개발 워크플로우 하네스",
-      "version": "0.13.1",
+      "version": "0.14.1",
       "author": {
         "name": "SeokRae",
         "email": "kslbsh@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sr-harness",
   "description": "karpathy-guidelines와 issue-driven development가 구조적으로 통합된 커스텀 개발 워크플로우 하네스",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "author": {
     "name": "SeokRae",
     "email": "kslbsh@gmail.com"

--- a/scripts/setup-ralph.sh
+++ b/scripts/setup-ralph.sh
@@ -15,10 +15,19 @@ if [[ ! -f "$PLAN_FILE" ]]; then
   exit 1
 fi
 
-WORKTREE_CHECK=$(git worktree list | grep -F "$(pwd)" | grep -v "bare" || true)
-if [[ -z "$WORKTREE_CHECK" ]]; then
-  echo "❌ worktree 밖에서 실행됨. .claude/worktrees/ 안으로 이동하세요." >&2
-  exit 1
+if [[ -d ".obsidian" ]]; then
+  # Obsidian vault: worktree 없이 feature 브랜치에서 직접 작업
+  CURRENT_BRANCH=$(git branch --show-current)
+  if [[ "$CURRENT_BRANCH" == "main" ]]; then
+    echo "❌ vault 프로젝트는 feature 브랜치에서 실행하세요. (현재: main)" >&2
+    exit 1
+  fi
+else
+  WORKTREE_CHECK=$(git worktree list | grep -F "$(pwd)" | grep -v "bare" || true)
+  if [[ -z "$WORKTREE_CHECK" ]]; then
+    echo "❌ worktree 밖에서 실행됨. .claude/worktrees/ 안으로 이동하세요." >&2
+    exit 1
+  fi
 fi
 
 if [[ -f "$STATE_FILE" ]]; then

--- a/skills/finish/SKILL.md
+++ b/skills/finish/SKILL.md
@@ -32,10 +32,15 @@ git checkout main
 git pull origin main
 ```
 
-### 4. Worktree 정리 (worktree 사용 시)
+> **Obsidian vault**: `git checkout main`이 feature 브랜치 → main 전환을 겸한다.
+> pull 완료 시점에 Obsidian vault에 파일이 즉시 반영된다.
+
+### 4. Worktree 정리 (코드 프로젝트 + worktree 사용 시)
 ```bash
 git worktree remove .claude/worktrees/{description}
 ```
+
+> **Obsidian vault**: worktree 없이 작업했으므로 이 단계 생략.
 
 ### 4.5. 로컬 브랜치 삭제
 ```bash

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -25,7 +25,8 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/setup-ralph.sh"
 
 에러가 있으면 스크립트가 메시지와 함께 종료된다:
 - `session-plan.md 없음` → `plan` 스킬로 먼저 계획 작성
-- `worktree 밖` → `issue` 스킬로 worktree 생성
+- `worktree 밖` (코드 프로젝트) → `issue` 스킬로 worktree 생성
+- `main 브랜치` (vault 프로젝트) → `issue` 스킬로 feature 브랜치 생성
 - `활성 루프 존재` → cleanup 스크립트 실행
 
 ### 2. 첫 번째 반복 즉시 시작
@@ -64,6 +65,7 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-ralph.sh"
 ## 금지 사항
 
 - plan 없이 ralph 시작 금지
-- worktree 밖에서 실행 금지
+- 코드 프로젝트: worktree 밖에서 실행 금지
+- Obsidian vault (`.obsidian/` 있음): main 브랜치에서 실행 금지 (feature 브랜치 필요)
 - Tasks 미완료 상태에서 promise 출력 금지
 - 테스트 실패 상태에서 promise 출력 금지

--- a/skills/start/SKILL.md
+++ b/skills/start/SKILL.md
@@ -21,11 +21,14 @@ description: sr-harness 세션 진입점. 모든 대화 시작 시 반드시 먼
    - `paused`: "일시 중단된 goal이 있습니다: {goal 텍스트}" → `/goal resume` 으로 재개 안내
    - 없으면 → 다음 단계
 
-3. 활성 worktree 감지
+3. 진행 중 작업 감지
    ```bash
+   ls .obsidian/ 2>/dev/null && echo "vault" || echo "code"
    git worktree list
+   git branch --show-current
    ```
-   - `.claude/worktrees/`에 활성 worktree가 있으면 → 해당 작업 재개 안내
+   - **코드 프로젝트**: `.claude/worktrees/`에 활성 worktree가 있으면 → 해당 작업 재개 안내
+   - **Obsidian vault** (`.obsidian/` 있음): 현재 브랜치가 `feature/`로 시작하면 → 해당 작업 재개 안내
    - 없으면 → 새 작업 시작
 
 4. 아래 라우팅 표로 적절한 스킬 호출


### PR DESCRIPTION
## 변경 내용

Obsidian vault(`.obsidian/` 있음)에서 worktree 없이 feature 브랜치 직접 작업 시 ralph·start·finish가 정상 동작하도록 수정.

### 핵심 문제
vault에서 ralph 실행 시 `setup-ralph.sh`의 worktree 체크에서 차단됨.

### 수정 파일

| 파일 | 변경 내용 |
|------|---------|
| `scripts/setup-ralph.sh` | `.obsidian/` 감지 시 worktree 체크 → feature 브랜치 체크로 전환 |
| `skills/ralph/SKILL.md` | vault 예외 규칙 명시 (main 브랜치 금지) |
| `skills/start/SKILL.md` | step 3에 vault feature 브랜치 감지 추가 |
| `skills/finish/SKILL.md` | vault용 단계 안내 추가 (worktree 생략, pull로 Obsidian 반영) |
| `.claude-plugin/plugin.json` | 0.14.0 → 0.14.1 |
| `.claude-plugin/marketplace.json` | 0.13.1 → 0.14.1 |

Closes #69