### PR TITLE
feat: worktree 제거 — feature 브랜치 직접 체크아웃으로 변경 (v0.15.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "karpathy-guidelines와 issue-driven development가 구조적으로 통합된 커스텀 개발 워크플로우 하네스",
-    "version": "0.15.0"
+    "version": "0.15.1"
   },
   "plugins": [
     {
       "name": "sr-harness",
       "source": "./",
       "description": "karpathy-guidelines와 issue-driven development가 구조적으로 통합된 커스텀 개발 워크플로우 하네스",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "author": {
         "name": "SeokRae",
         "email": "kslbsh@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sr-harness",
   "description": "karpathy-guidelines와 issue-driven development가 구조적으로 통합된 커스텀 개발 워크플로우 하네스",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "author": {
     "name": "SeokRae",
     "email": "kslbsh@gmail.com"

--- a/skills/execute/SKILL.md
+++ b/skills/execute/SKILL.md
@@ -8,23 +8,9 @@ description: 구현 계획을 실행하는 스킬. "구현해줘", "만들어줘
 구현 시작 전 karpathy 체크포인트를 통과해야 한다.
 단계별로 실행하고, 각 단계가 끝나면 verify 후 다음으로 넘어간다.
 
-## 전제 조건 (브랜치/Worktree 확인)
+## 전제 조건 (브랜치 확인)
 
-먼저 프로젝트 유형을 감지한다:
-
-```bash
-ls .obsidian/ 2>/dev/null && echo "vault" || echo "code"
-```
-
-**코드 프로젝트**: 현재 디렉토리가 worktree(`.claude/worktrees/{description}`) 안인지 확인한다.
-- 맞으면 → 진행
-- 아니면 → `issue`로 돌아가서 worktree 생성
-
-```bash
-git worktree list | grep "$(pwd)"
-```
-
-**Obsidian vault**: feature 브랜치에 있는지 확인한다. main이면 → `issue`로 돌아가서 브랜치 생성.
+feature 브랜치에 있는지 확인한다. main이면 → `issue`로 돌아가서 브랜치 생성.
 
 ```bash
 git branch --show-current  # feature/* 여야 함, main이면 안 됨

--- a/skills/finish/SKILL.md
+++ b/skills/finish/SKILL.md
@@ -32,17 +32,7 @@ git checkout main
 git pull origin main
 ```
 
-> **Obsidian vault**: `git checkout main`이 feature 브랜치 → main 전환을 겸한다.
-> pull 완료 시점에 Obsidian vault에 파일이 즉시 반영된다.
-
-### 4. Worktree 정리 (코드 프로젝트 + worktree 사용 시)
-```bash
-git worktree remove .claude/worktrees/{description}
-```
-
-> **Obsidian vault**: worktree 없이 작업했으므로 이 단계 생략.
-
-### 4.5. 로컬 브랜치 삭제
+### 4. 로컬 브랜치 삭제
 ```bash
 git branch -d feature/{N}-{description}
 ```

--- a/skills/issue/SKILL.md
+++ b/skills/issue/SKILL.md
@@ -31,52 +31,24 @@ git checkout -b feature/{issue-number}-{short-description}
 - 다른 feature 브랜치에서 분기 (체인 브랜치 금지)
 - 한 브랜치에 여러 Issue 혼재
 
-### 3. 프로젝트 유형 감지 후 격리 방식 결정
+### 3. 프로젝트 유형 감지
 
 ```bash
 ls .obsidian/ 2>/dev/null && echo "vault" || echo "code"
 ```
 
-#### 코드 프로젝트 (`.obsidian/` 없음) → Worktree 생성
+브랜치가 이미 체크아웃된 상태이므로 별도 격리 작업은 없다.
+모든 파일 작업은 프로젝트 루트에서 수행한다.
 
-```bash
-git worktree add .claude/worktrees/{short-description} feature/{issue-number}-{short-description}
-```
-
-이후 모든 파일 작업은 worktree 안에서 수행한다.
-
-**컨벤션**:
-- 위치: `.claude/worktrees/` (프로젝트 `.gitignore`에 포함 확인)
-- 이름: 브랜치의 `{short-description}` 부분 그대로 사용
-- `.gitignore`에 `.claude/worktrees/` 없으면 추가 후 커밋
-
-#### Obsidian vault (`.obsidian/` 있음) → 브랜치에서 직접 작업
-
-worktree를 생성하지 않는다. Obsidian은 vault 루트 하나만 바라보기 때문에
-worktree 파일은 머지 전까지 Obsidian에서 보이지 않아 의미가 없다.
-feature 브랜치에서 직접 작업하고, 작업 결과를 바로 Obsidian에서 확인할 수 있다.
-
-```bash
-git checkout feature/{issue-number}-{short-description}
-```
+> **Worktree는 사용하지 않는다.** 단일 순차 개발에서 worktree를 쓰면
+> 메인 IDE에서 변경 내용이 보이지 않아 PR 리뷰 전 코드 확인이 불편하다.
+> 병렬 브랜치 작업이 필요한 경우에만 수동으로 worktree를 생성한다.
 
 ### 4. 확인 출력
 
-코드 프로젝트:
 ```
 ✅ Issue #N 생성: {제목}
-✅ 브랜치 생성: feature/{N}-{description}
-✅ Worktree 생성: .claude/worktrees/{description}
-✅ 현재 위치: .claude/worktrees/{description}
-
-다음 단계: execute
-```
-
-Obsidian vault:
-```
-✅ Issue #N 생성: {제목}
-✅ 브랜치 생성: feature/{N}-{description}
-ℹ️  Vault 프로젝트 — worktree 없이 브랜치에서 직접 작업
+✅ 브랜치 생성 및 체크아웃: feature/{N}-{description}
 
 다음 단계: execute
 ```


### PR DESCRIPTION
## 변경 내용

단일 순차 개발에서 worktree를 쓰면 메인 IDE에서 변경 내용이 보이지 않아
PR 리뷰 전 코드 확인이 불편하다는 피드백을 반영.

### 수정된 스킬

- **issue**: 코드 프로젝트에서 worktree 생성 단계 제거 → feature 브랜치 직접 체크아웃
- **execute**: worktree 확인 로직 제거 → feature 브랜치 확인으로 통일 (vault과 동일)
- **finish**: worktree 정리 단계(Step 4) 제거

### 버전

0.15.0 → 0.15.1 (patch)