### PR TITLE
fix: ralph worktree 전제 제거 — feature 브랜치 기준 통일

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "karpathy-guidelines와 issue-driven development가 구조적으로 통합된 커스텀 개발 워크플로우 하네스",
-    "version": "0.16.0"
+    "version": "0.16.1"
   },
   "plugins": [
     {
       "name": "sr-harness",
       "source": "./",
       "description": "karpathy-guidelines와 issue-driven development가 구조적으로 통합된 커스텀 개발 워크플로우 하네스",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "author": {
         "name": "SeokRae",
         "email": "kslbsh@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sr-harness",
   "description": "karpathy-guidelines와 issue-driven development가 구조적으로 통합된 커스텀 개발 워크플로우 하네스",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "author": {
     "name": "SeokRae",
     "email": "kslbsh@gmail.com"

--- a/scripts/setup-ralph.sh
+++ b/scripts/setup-ralph.sh
@@ -15,19 +15,12 @@ if [[ ! -f "$PLAN_FILE" ]]; then
   exit 1
 fi
 
-if [[ -d ".obsidian" ]]; then
-  # Obsidian vault: worktree 없이 feature 브랜치에서 직접 작업
-  CURRENT_BRANCH=$(git branch --show-current)
-  if [[ "$CURRENT_BRANCH" == "main" ]]; then
-    echo "❌ vault 프로젝트는 feature 브랜치에서 실행하세요. (현재: main)" >&2
-    exit 1
-  fi
-else
-  WORKTREE_CHECK=$(git worktree list | grep -F "$(pwd)" | grep -v "bare" || true)
-  if [[ -z "$WORKTREE_CHECK" ]]; then
-    echo "❌ worktree 밖에서 실행됨. .claude/worktrees/ 안으로 이동하세요." >&2
-    exit 1
-  fi
+# feature 브랜치 확인 (vault·code 공통 — worktree 미사용, v0.15.1+)
+CURRENT_BRANCH=$(git branch --show-current)
+if [[ "$CURRENT_BRANCH" == "main" ]] || [[ -z "$CURRENT_BRANCH" ]]; then
+  echo "❌ feature 브랜치에서 실행하세요. (현재: ${CURRENT_BRANCH:-detached HEAD})" >&2
+  echo "   issue 스킬로 feature 브랜치를 먼저 생성하세요." >&2
+  exit 1
 fi
 
 if [[ -f "$STATE_FILE" ]]; then
@@ -131,7 +124,6 @@ cat >> "$STATE_FILE" <<PROMPT_MID
 
 - Read before Write: 수정 전 대상 파일 반드시 먼저 읽기
 - git add . 사용 금지 — 관련 파일만 명시적으로 지정
-- worktree 경로 내에서만 파일 수정 (main 워크트리 직접 수정 금지)
 - 요청한 것만 구현 — 추가 기능·리팩터 금지
 
 ## 매 반복 실행 순서

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -18,15 +18,14 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/setup-ralph.sh"
 ```
 
 스크립트가 자동으로 처리하는 것:
-- `.claude/session-plan.md` 존재 + worktree 위치 확인
+- `.claude/session-plan.md` 존재 + feature 브랜치 확인
 - 기존 Ralph 루프 중복 실행 방지
 - `.claude/settings.local.json` 백업 → bypass 권한 추가
 - `.claude/ralph-loop.local.md` 상태 파일 생성 (session_id, max_iterations, karpathy 원칙 포함 프롬프트)
 
 에러가 있으면 스크립트가 메시지와 함께 종료된다:
 - `session-plan.md 없음` → `plan` 스킬로 먼저 계획 작성
-- `worktree 밖` (코드 프로젝트) → `issue` 스킬로 worktree 생성
-- `main 브랜치` (vault 프로젝트) → `issue` 스킬로 feature 브랜치 생성
+- `main 브랜치` 또는 `detached HEAD` → `issue` 스킬로 feature 브랜치 생성
 - `활성 루프 존재` → cleanup 스크립트 실행
 
 ### 2. 첫 번째 반복 즉시 시작
@@ -65,7 +64,6 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-ralph.sh"
 ## 금지 사항
 
 - plan 없이 ralph 시작 금지
-- 코드 프로젝트: worktree 밖에서 실행 금지
-- Obsidian vault (`.obsidian/` 있음): main 브랜치에서 실행 금지 (feature 브랜치 필요)
+- main 브랜치에서 실행 금지 (feature 브랜치 필요 — vault·code 공통)
 - Tasks 미완료 상태에서 promise 출력 금지
 - 테스트 실패 상태에서 promise 출력 금지


### PR DESCRIPTION
## 변경 내용
ralph의 worktree 전제를 제거하고 `issue` 스킬(v0.15.1, worktree 폐기)과 일관되게 **feature 브랜치 기준**으로 통일.

- **setup-ralph.sh**: `.obsidian` 분기 + `git worktree list | grep $(pwd)` 체크 제거 → vault·code 공통 feature 브랜치 체크(main/detached HEAD 차단). 프롬프트 본문의 "worktree 경로 내에서만 수정" 잔재 제거.
- **ralph/SKILL.md**: "worktree 밖 → issue로 worktree 생성" 죽은 안내 + 금지사항의 worktree/vault 이중 구분 → "main 브랜치에서 실행 금지" 단일.
- **버전**: 0.16.0 → 0.16.1 (plugin.json + marketplace.json 동기화).

### 발견 경위
기존 code 블록은 브랜치를 보지 않고 worktree만 확인했는데, `git worktree list`가 메인 작업트리를 항상 포함하므로 **루트 실행 시 무의미하게 통과 + main을 차단하지 못하는** 버그가 있었음. 재현으로 확인.

## 테스트
격리된 임시 code 프로젝트(`.obsidian` 없음)에서 setup-ralph.sh 재현:
- `feature + root` → exit 0 통과
- `main + root` → exit 1 차단 ("feature 브랜치에서 실행하세요")

Closes #75