### PR TITLE
feat: add Codex dual-runtime plugin manifest

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "karpathy-guidelines와 issue-driven development가 구조적으로 통합된 커스텀 개발 워크플로우 하네스",
-    "version": "0.16.3"
+    "version": "0.17.0"
   },
   "plugins": [
     {
       "name": "sr-harness",
       "source": "./",
       "description": "karpathy-guidelines와 issue-driven development가 구조적으로 통합된 커스텀 개발 워크플로우 하네스",
-      "version": "0.16.3",
+      "version": "0.17.0",
       "author": {
         "name": "SeokRae",
         "email": "kslbsh@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sr-harness",
   "description": "karpathy-guidelines와 issue-driven development가 구조적으로 통합된 커스텀 개발 워크플로우 하네스",
-  "version": "0.16.3",
+  "version": "0.17.0",
   "author": {
     "name": "SeokRae",
     "email": "kslbsh@gmail.com"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,44 @@
+{
+  "name": "sr-harness",
+  "version": "0.17.0",
+  "description": "A structured development workflow harness with issue-driven planning, verification gates, and surgical implementation checkpoints.",
+  "author": {
+    "name": "SeokRae",
+    "email": "kslbsh@gmail.com",
+    "url": "https://github.com/SeokRae"
+  },
+  "homepage": "https://github.com/SeokRae/sr-harness",
+  "repository": "https://github.com/SeokRae/sr-harness",
+  "license": "MIT",
+  "keywords": [
+    "harness",
+    "workflow",
+    "issue-driven",
+    "verification",
+    "tdd",
+    "codex",
+    "claude"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "sr-harness",
+    "shortDescription": "Issue-driven workflow and verification gates for coding agents",
+    "longDescription": "Use sr-harness to guide work through brainstorming, planning, issue creation, implementation, debugging, verification, review, release, and finish workflows. The shared skills are designed to run in both Claude Code and Codex, with runtime-specific behavior documented separately.",
+    "developerName": "SeokRae",
+    "category": "Coding",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "defaultPrompt": [
+      "Use sr-harness to plan and implement this change with verification gates.",
+      "Start an issue-driven workflow for this repository."
+    ],
+    "websiteURL": "https://github.com/SeokRae/sr-harness",
+    "privacyPolicyURL": "https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement",
+    "termsOfServiceURL": "https://docs.github.com/en/site-policy/github-terms/github-terms-of-service",
+    "brandColor": "#2563EB",
+    "screenshots": []
+  }
+}

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,9 +1,10 @@
 # sr-harness
 
-Claude Code의 작업 방식을 직접 설계하는 하네스
+코딩 에이전트의 작업 방식을 직접 설계하는 하네스
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-Plugin-blueviolet)](https://claude.ai/code)
+[![Codex](https://img.shields.io/badge/Codex-Plugin-2563eb)](.codex-plugin/plugin.json)
 [![Status](https://img.shields.io/badge/Status-Early%20Stage-orange)](.)
 [![Workflow Cycle](https://img.shields.io/badge/워크플로우-인터랙티브%20다이어그램-68b6ff)](https://seokrae.github.io/sr-harness/)
 
@@ -13,7 +14,7 @@ Claude Code의 작업 방식을 직접 설계하는 하네스
 
 ## 왜 만들었나
 
-Claude Code로 개발하다 보면 반복적으로 겪는 패턴이 있다.
+코딩 에이전트로 개발하다 보면 반복적으로 겪는 패턴이 있다.
 
 - 원칙은 알고 있는데, 막상 구현할 때 지켜지지 않는다
 - "Issue 먼저 만들고 브랜치 생성"이 규칙인데, 흐름이 끊기면 건너뛰게 된다
@@ -45,6 +46,13 @@ execute 기존 코드 수정 시:
 
 ## 설치
 
+sr-harness는 Claude Code와 Codex manifest를 모두 제공한다:
+
+- Claude Code: `.claude-plugin/plugin.json`
+- Codex: `.codex-plugin/plugin.json`
+
+### Claude Code
+
 ```bash
 # 마켓플레이스 추가
 claude plugins marketplace add https://github.com/SeokRae/sr-harness.git
@@ -57,10 +65,16 @@ claude plugins install sr-harness@sr-harness
 ```bash
 claude plugins list
 #   ❯ sr-harness@sr-harness
-#     Version: 0.1.0
+#     Version: 0.17.0
 #     Scope: user
 #     Status: ✔ enabled
 ```
+
+### Codex
+
+Codex 지원은 `.codex-plugin/plugin.json` manifest 기준으로 준비되어 있다. Codex plugin marketplace 또는 local plugin source 설정을 통해 설치하면, 동일한 `skills/*/SKILL.md` 스킬을 Codex에서 사용할 수 있다.
+
+런타임별 차이는 [`docs/RUNTIME-COMPATIBILITY.md`](./docs/RUNTIME-COMPATIBILITY.md)에 정리되어 있다.
 
 ---
 
@@ -170,6 +184,8 @@ cd sr-harness
 git add . && git commit -m "fix: 스킬 내용 수정" && git push
 claude plugins marketplace update sr-harness
 ```
+
+스킬 목록이나 버전을 변경할 때는 `.claude-plugin/plugin.json`과 `.codex-plugin/plugin.json`을 함께 갱신한다.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # sr-harness
 
-> A custom Claude Code harness for designing how your AI assistant works — not the other way around.
+> A custom coding-agent harness for designing how your AI assistant works — not the other way around.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-Plugin-blueviolet)](https://claude.ai/code)
+[![Codex](https://img.shields.io/badge/Codex-Plugin-2563eb)](.codex-plugin/plugin.json)
 [![Status](https://img.shields.io/badge/Status-Early%20Stage-orange)](.)
 [![Workflow Cycle](https://img.shields.io/badge/Workflow-Interactive%20Diagram-68b6ff)](https://seokrae.github.io/sr-harness/)
 
@@ -13,10 +14,10 @@
 
 ## Why
 
-When working with Claude Code day-to-day, the same patterns keep breaking down:
+When working with coding agents day-to-day, the same patterns keep breaking down:
 
 - Principles exist as background rules — they load into context but don't get enforced when it matters
-- Issue-Driven Development lives in a CLAUDE.md file, disconnected from the actual workflow
+- Issue-Driven Development lives in a project memory file, disconnected from the actual workflow
 - Brainstorming, planning, and implementation feel like separate sessions, not one continuous flow
 
 sr-harness structures these into a single workflow where each stage enforces the right behavior automatically.
@@ -45,6 +46,13 @@ From idea to PR, each skill hands off naturally to the next.
 
 ## Installation
 
+sr-harness ships manifests for both Claude Code and Codex:
+
+- Claude Code: `.claude-plugin/plugin.json`
+- Codex: `.codex-plugin/plugin.json`
+
+### Claude Code
+
 ```bash
 # Add marketplace
 claude plugins marketplace add https://github.com/SeokRae/sr-harness.git
@@ -57,10 +65,16 @@ Verify:
 ```bash
 claude plugins list
 #   ❯ sr-harness@sr-harness
-#     Version: 0.16.1
+#     Version: 0.17.0
 #     Scope: user
 #     Status: ✔ enabled
 ```
+
+### Codex
+
+Codex support is manifest-ready through `.codex-plugin/plugin.json`. Install it through your Codex plugin marketplace or local plugin source configuration. Once installed, the shared `skills/*/SKILL.md` files are available to Codex.
+
+Runtime-specific behavior is documented in [`docs/RUNTIME-COMPATIBILITY.md`](./docs/RUNTIME-COMPATIBILITY.md).
 
 ---
 
@@ -130,7 +144,7 @@ start
 | `review` | Receive review feedback → back to execute |
 | `finish` | Merge + delete branch + pull main |
 | `ralph` | Automated execute→verify loop until pass (bypass mode) |
-| `goal` | Goal-driven autonomous execution via Stop hook |
+| `goal` | Goal-driven autonomous execution via Stop hook in Claude Code; workflow guidance in Codex until a Codex-native loop is added |
 | `release` | Create a GitHub Release (version + auto-generated notes) |
 | `abort` | Cancel work · clean up branch |
 | `pause` | Suspend session · hand off to next session |
@@ -190,6 +204,8 @@ cd sr-harness
 git add . && git commit -m "fix: update skill" && git push
 claude plugins marketplace update sr-harness
 ```
+
+When changing the skill list or version, update both `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json`.
 
 ---
 

--- a/docs/RUNTIME-COMPATIBILITY.md
+++ b/docs/RUNTIME-COMPATIBILITY.md
@@ -1,0 +1,53 @@
+# Runtime Compatibility
+
+sr-harness is a dual-runtime plugin. Claude Code and Codex share the same skill source files under `skills/`, while each runtime owns its own plugin manifest and runtime-specific behavior.
+
+## Manifest Layout
+
+| Runtime | Manifest | Purpose |
+| --- | --- | --- |
+| Claude Code | `.claude-plugin/plugin.json` | Claude plugin metadata and skill registration |
+| Claude Code | `.claude-plugin/marketplace.json` | Claude marketplace metadata |
+| Codex | `.codex-plugin/plugin.json` | Codex plugin metadata and skill registration |
+
+Version bumps must keep both manifests in sync.
+
+## Shared Contract
+
+The reusable workflow contract lives in `skills/*/SKILL.md`.
+
+Shared skills should prefer runtime-neutral wording:
+
+- Use `agent` when the behavior applies to both Claude Code and Codex.
+- Use `Claude Code` or `Codex` only for runtime-specific commands, hooks, or UI behavior.
+- Keep checklist, planning, debugging, and verification rules in the shared skill file when they do not require a runtime-specific tool.
+
+## Runtime-Specific Behavior
+
+Claude-specific behavior currently includes:
+
+- `.claude/session-plan.md`
+- `.claude/goal-state.json`
+- `.claude/ralph-loop.local.md`
+- `.claude/settings.local.json`
+- `CLAUDE_PLUGIN_ROOT`
+- `CLAUDE_CODE_SESSION_ID`
+- Stop hooks used by `goal` and `ralph`
+
+Codex can load the shared skills through `.codex-plugin/plugin.json`, but Codex does not automatically install the Claude Stop-hook loop. In Codex, `goal` and `ralph` should be treated as workflow guidance until a Codex-native loop implementation is added.
+
+## State Path Policy
+
+New runtime-neutral state should live under `.sr-harness/`.
+
+Use `.claude/` only for Claude Code hook configuration or backward compatibility. If a skill needs persistent state in both runtimes, document both paths explicitly or migrate to `.sr-harness/` with a fallback for legacy `.claude/` files.
+
+## Change Checklist
+
+When adding or changing a skill:
+
+1. Keep the shared behavior in `skills/<name>/SKILL.md`.
+2. Put Claude-only behavior in a clearly labeled `Claude Code` subsection.
+3. Put Codex-only behavior in a clearly labeled `Codex` subsection.
+4. Update `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json` together when the skill list or version changes.
+5. Validate the Codex manifest with the Codex plugin validator before release.

--- a/skills/dev-architecture/SKILL.md
+++ b/skills/dev-architecture/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dev-architecture
-description: 아키텍처 설계 원칙 체크리스트. execute 시작 전 또는 설계 중 참조. Hexagonal Architecture·레이어 분리·패키지 구조 세 섹션으로 구성. Keywords: 아키텍처, hexagonal, 레이어, 패키지, 설계, architecture, layer, package, ports and adapters
+description: "아키텍처 설계 원칙 체크리스트. execute 시작 전 또는 설계 중 참조. Hexagonal Architecture·레이어 분리·패키지 구조 세 섹션으로 구성. Keywords: 아키텍처, hexagonal, 레이어, 패키지, 설계, architecture, layer, package, ports and adapters"
 ---
 
 # dev-architecture

--- a/skills/dev-coding-principles/SKILL.md
+++ b/skills/dev-coding-principles/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dev-coding-principles
-description: 코딩 품질 원칙 체크리스트. execute 시작 전 또는 코드 작성 중 참조. 네이밍·예외 처리·테스트 세 섹션으로 구성. Keywords: 코딩 원칙, 네이밍, 예외처리, 테스트, 품질, coding standards, naming, exception, test
+description: "코딩 품질 원칙 체크리스트. execute 시작 전 또는 코드 작성 중 참조. 네이밍·예외 처리·테스트 세 섹션으로 구성. Keywords: 코딩 원칙, 네이밍, 예외처리, 테스트, 품질, coding standards, naming, exception, test"
 ---
 
 # dev-coding-principles

--- a/skills/dev-stack-java/SKILL.md
+++ b/skills/dev-stack-java/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dev-stack-java
-description: Java/Spring Boot 관용구 체크리스트. Java 프로젝트의 execute 시 참조. Spring Boot·JPA·예외처리 패턴 세 섹션으로 구성. 프로젝트 CLAUDE.md에 선언하여 활성화. Keywords: Java, Spring Boot, JPA, 스프링, 관용구, spring idioms, dependency injection, transaction, exception handler
+description: "Java/Spring Boot 관용구 체크리스트. Java 프로젝트의 execute 시 참조. Spring Boot·JPA·예외처리 패턴 세 섹션으로 구성. 프로젝트 CLAUDE.md에 선언하여 활성화. Keywords: Java, Spring Boot, JPA, 스프링, 관용구, spring idioms, dependency injection, transaction, exception handler"
 ---
 
 # dev-stack-java

--- a/skills/goal/SKILL.md
+++ b/skills/goal/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: goal
-description: plan/worktree 없이 자율 실행. /goal "목표" → Stop hook 기반으로 목표 달성까지 반복. pause/resume/clear/status 지원. Keywords: goal, 목표, 자율 실행, 자동 반복, ralph 대안
+description: "plan/worktree 없이 자율 실행. /goal \"목표\" → Stop hook 기반으로 목표 달성까지 반복. pause/resume/clear/status 지원. Keywords: goal, 목표, 자율 실행, 자동 반복, ralph 대안"
 allowed-tools: ["Bash(${CLAUDE_PLUGIN_ROOT}/scripts/setup-goal.sh:*)", "Bash(${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-goal.sh:*)"]
 ---
 

--- a/skills/meta/SKILL.md
+++ b/skills/meta/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: meta
-description: 지정한 스킬을 피진화체로 삼아 Meta-Harness 방식의 1회 진화 루프를 실행한다. 실행 로그·결과물을 분석하고 개선 후보 3개를 제안·구현. Keywords: meta, evolve, 스킬 진화, 개선, evolution
+description: "지정한 스킬을 피진화체로 삼아 Meta-Harness 방식의 1회 진화 루프를 실행한다. 실행 로그·결과물을 분석하고 개선 후보 3개를 제안·구현. Keywords: meta, evolve, 스킬 진화, 개선, evolution"
 ---
 
 # sr-harness:meta — 스킬 진화 루프


### PR DESCRIPTION
## Summary
- Add .codex-plugin/plugin.json so sr-harness can be loaded by Codex while preserving the Claude plugin manifest
- Bump plugin metadata to 0.17.0 across Claude and Codex manifests
- Document runtime boundaries for shared skills, Claude-only hooks/state, and future state path policy
- Quote strict-YAML skill descriptions required by Codex plugin validation

## Testing
- python3 /Users/sr/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py .
- git diff --check

## Notes
- Codex can load the shared skills through the new manifest, but Claude Stop-hook loops for goal/ralph are documented as Claude-specific until a Codex-native loop is implemented.