### PR TITLE
chore: add Codex marketplace entry

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "sr-harness",
+  "interface": {
+    "displayName": "sr-harness"
+  },
+  "plugins": [
+    {
+      "name": "sr-harness",
+      "source": {
+        "source": "local",
+        "path": "./"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Coding"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add .agents/plugins/marketplace.json so Codex can discover sr-harness inside the configured sr-harness marketplace
- Point the marketplace entry at the repository root, where .codex-plugin/plugin.json already lives

## Testing
- python3 -m json.tool .agents/plugins/marketplace.json
- python3 /Users/sr/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py .
- git diff --check