### PR TITLE
chore: commit-msg 훅 추가 — 이슈번호·prefix 강제, main 직접 커밋 차단

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,35 @@
+#!/bin/sh
+# commit-msg 훅 — 이슈 드리븐 워크플로우 강제 (#85 후속)
+# 검사: (1) main 직접 커밋 차단 (2) 이슈번호(#N) 필수 (3) prefix 필수
+# 활성화: git config core.hooksPath .githooks
+
+msg_file="$1"
+first_line=$(head -n1 "$msg_file")
+
+# merge / revert / fixup / squash 커밋은 통과
+case "$first_line" in
+  Merge*|Revert*|fixup!*|squash!*) exit 0 ;;
+esac
+
+# 1. main 직접 커밋 차단
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+if [ "$branch" = "main" ]; then
+  echo "✖ main 직접 커밋 금지 — feature/{이슈번호}-{설명} 브랜치를 사용하세요" >&2
+  echo "  (CLAUDE.md 작업 흐름: gh issue create → git checkout -b feature/{N}-{desc})" >&2
+  exit 1
+fi
+
+# 2. 이슈번호(#N) 필수
+if ! grep -qE '(^|[^A-Za-z0-9&])#[0-9]+' "$msg_file"; then
+  echo "✖ 커밋 메시지에 이슈번호(#N)가 없습니다" >&2
+  echo "  예: chore: 설정 변경 (#123)" >&2
+  exit 1
+fi
+
+# 3. 커밋 prefix 필수 (feat|fix|chore|docs)
+if ! echo "$first_line" | grep -qE '^(feat|fix|chore|docs)(\([^)]+\))?: '; then
+  echo "✖ 커밋 prefix가 없습니다 — feat: | fix: | chore: | docs: 중 하나 필요" >&2
+  exit 1
+fi
+
+exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,3 +52,19 @@ gh issue create → git checkout -b feature/{N}-{desc} → 구현 + 버전 bump
 ```
 
 커밋 prefix: `feat:` (스킬 추가), `fix:` (버그), `chore:` (설정·버전 bump), `docs:` (문서)
+
+## Git 훅
+
+`.githooks/commit-msg`가 이슈 드리븐 워크플로우를 강제한다 (#85 후속):
+
+- main 직접 커밋 차단 (feature 브랜치 필수)
+- 커밋 메시지에 이슈번호 `(#N)` 필수
+- prefix(`feat:|fix:|chore:|docs:`) 필수
+- `Merge`/`Revert`/`fixup!`/`squash!` 커밋은 예외
+
+클론 후 1회 활성화:
+
+```bash
+chmod +x .githooks/commit-msg
+git config core.hooksPath .githooks
+```


### PR DESCRIPTION
Closes #86

## 변경 내용

- `.githooks/commit-msg` 추가: main 직접 커밋 차단, 이슈번호(#N) 필수, prefix(feat|fix|chore|docs) 필수 — Merge/Revert/fixup!/squash! 예외
- CLAUDE.md `## Git 훅` 섹션 추가 (활성화: `chmod +x .githooks/commit-msg` + `git config core.hooksPath .githooks`)

## 비고

- 플러그인 페이로드(skills) 변경 없음 → 버전 bump 없음
- 웹 UI 커밋이라 실행 권한(+x) 미포함 — 활성화 명령에 chmod 포함으로 보완