### PR TITLE
fix: pause·start·goal worktree 잔재 정리 — feature 브랜치 기준 통일 (0.17.3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "karpathy-guidelines와 issue-driven development가 구조적으로 통합된 커스텀 개발 워크플로우 하네스",
-    "version": "0.17.2"
+    "version": "0.17.3"
   },
   "plugins": [
     {
       "name": "sr-harness",
       "source": "./",
       "description": "karpathy-guidelines와 issue-driven development가 구조적으로 통합된 커스텀 개발 워크플로우 하네스",
-      "version": "0.17.2",
+      "version": "0.17.3",
       "author": {
         "name": "SeokRae",
         "email": "kslbsh@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sr-harness",
   "description": "karpathy-guidelines와 issue-driven development가 구조적으로 통합된 커스텀 개발 워크플로우 하네스",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "author": {
     "name": "SeokRae",
     "email": "kslbsh@gmail.com"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sr-harness",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "description": "A structured development workflow harness with issue-driven planning, verification gates, and surgical implementation checkpoints.",
   "author": {
     "name": "SeokRae",

--- a/README.ko.md
+++ b/README.ko.md
@@ -65,7 +65,7 @@ claude plugins install sr-harness@sr-harness
 ```bash
 claude plugins list
 #   ❯ sr-harness@sr-harness
-#     Version: 0.17.2
+#     Version: 0.17.3
 #     Scope: user
 #     Status: ✔ enabled
 ```

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Verify:
 ```bash
 claude plugins list
 #   ❯ sr-harness@sr-harness
-#     Version: 0.17.2
+#     Version: 0.17.3
 #     Scope: user
 #     Status: ✔ enabled
 ```

--- a/plugins/sr-harness/.codex-plugin/plugin.json
+++ b/plugins/sr-harness/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sr-harness",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "description": "A structured development workflow harness with issue-driven planning, verification gates, and surgical implementation checkpoints.",
   "author": {
     "name": "SeokRae",

--- a/plugins/sr-harness/skills/goal/SKILL.md
+++ b/plugins/sr-harness/skills/goal/SKILL.md
@@ -108,7 +108,7 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-goal.sh"
 
 | | ralph | goal |
 |---|---|---|
-| 시작 조건 | session-plan.md + worktree 필수 | 목표 텍스트만 필요 |
+| 시작 조건 | session-plan.md + feature 브랜치 필수 | 목표 텍스트만 필요 |
 | 권한 변경 | bypass 권한 추가 | 변경 없음 |
 | 종료 조건 | verify 통과 | 목표 달성 선언 |
 | 재개 | 불가 | pause/resume 지원 |

--- a/plugins/sr-harness/skills/pause/SKILL.md
+++ b/plugins/sr-harness/skills/pause/SKILL.md
@@ -19,13 +19,13 @@ git status
 - 커밋하려면 `execute`의 커밋 단계로 안내
 - 커밋 안 해도 된다면 → 그대로 진행 (WIP 상태임을 session-plan에 기록)
 
-### 2. 활성 worktree 확인
+### 2. 활성 feature 브랜치 확인
 
 ```bash
-git worktree list
+git branch --show-current
 ```
 
-활성 worktree가 있으면 브랜치명과 Issue 번호를 session-plan에 기록한다.
+현재 브랜치가 `feature/{N}-{description}`이면 브랜치명과 Issue 번호를 session-plan에 기록한다.
 
 ### 3. session-plan.md 생성 또는 업데이트
 
@@ -38,8 +38,8 @@ git worktree list
 ---
 session: YYYY-MM-DD
 goal: {이번 세션에서 한 일 한 줄 요약}
-branch: feature/{N}-{description}   # 활성 worktree가 있을 때만
-issue: {N}                           # 활성 worktree가 있을 때만
+branch: feature/{N}-{description}   # feature 브랜치 작업 중일 때만
+issue: {N}                           # feature 브랜치 작업 중일 때만
 scope:
   - {완료한 작업 항목}
   - {남은 작업 항목}
@@ -73,6 +73,6 @@ session-plan.md 저장됨 → 다음 세션에서 start가 자동으로 이어�
 
 ## 주의
 
-- worktree는 제거하지 않는다 — 다음 세션에서 start가 감지해 재개 안내
+- feature 브랜치는 닫지 않는다 — 다음 세션에서 start가 감지해 재개 안내
 - session-plan.md는 프로젝트 루트 `.claude/` 아래에 저장 (vault는 `.claude/session-plan.md`)
 - 미완료 항목이 0개면 → finish로 안내 (브랜치를 완전히 닫을 수 있는 상태)

--- a/plugins/sr-harness/skills/start/SKILL.md
+++ b/plugins/sr-harness/skills/start/SKILL.md
@@ -24,12 +24,10 @@ description: sr-harness 세션 진입점. 모든 대화 시작 시 반드시 먼
 3. 진행 중 작업 감지
    ```bash
    ls .obsidian/ 2>/dev/null && echo "vault" || echo "code"
-   git worktree list
    git branch --show-current
    ```
-   - **코드 프로젝트**: `.claude/worktrees/`에 활성 worktree가 있으면 → 해당 작업 재개 안내
-   - **Obsidian vault** (`.obsidian/` 있음): 현재 브랜치가 `feature/`로 시작하면 → 해당 작업 재개 안내
-   - 없으면 → 새 작업 시작
+   - 프로젝트 유형 무관: 현재 브랜치가 `feature/`로 시작하면 → 해당 작업 재개 안내 (worktree 미사용 — v0.15.1)
+   - `main`이면 → 새 작업 시작
 
 4. 아래 라우팅 표로 적절한 스킬 호출
 

--- a/skills/goal/SKILL.md
+++ b/skills/goal/SKILL.md
@@ -108,7 +108,7 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-goal.sh"
 
 | | ralph | goal |
 |---|---|---|
-| 시작 조건 | session-plan.md + worktree 필수 | 목표 텍스트만 필요 |
+| 시작 조건 | session-plan.md + feature 브랜치 필수 | 목표 텍스트만 필요 |
 | 권한 변경 | bypass 권한 추가 | 변경 없음 |
 | 종료 조건 | verify 통과 | 목표 달성 선언 |
 | 재개 | 불가 | pause/resume 지원 |

--- a/skills/start/SKILL.md
+++ b/skills/start/SKILL.md
@@ -24,12 +24,10 @@ description: sr-harness 세션 진입점. 모든 대화 시작 시 반드시 먼
 3. 진행 중 작업 감지
    ```bash
    ls .obsidian/ 2>/dev/null && echo "vault" || echo "code"
-   git worktree list
    git branch --show-current
    ```
-   - **코드 프로젝트**: `.claude/worktrees/`에 활성 worktree가 있으면 → 해당 작업 재개 안내
-   - **Obsidian vault** (`.obsidian/` 있음): 현재 브랜치가 `feature/`로 시작하면 → 해당 작업 재개 안내
-   - 없으면 → 새 작업 시작
+   - 프로젝트 유형 무관: 현재 브랜치가 `feature/`로 시작하면 → 해당 작업 재개 안내 (worktree 미사용 — v0.15.1)
+   - `main`이면 → 새 작업 시작
 
 4. 아래 라우팅 표로 적절한 스킬 호출
 


### PR DESCRIPTION
Closes #90

## 변경 내용

- `start`: `.claude/worktrees/` 감지 제거 — 코드·vault 공통 feature 브랜치 기준 재개 감지
- `goal`: ralph 비교표 "worktree 필수" → "feature 브랜치 필수"
- `plugins/sr-harness/skills/` 사본 동일 반영 (pause·start·goal)
- 버전 0.17.2 → 0.17.3 (PATCH)

## 특이사항 (웹 UI 제약)

- `pause` 수정은 업로드 폼 라디오 오작동으로 **main 직접 커밋**(19b8768)됨 — 워크플로우 일탈, 데일리 로그에 기록
- 브랜치명 기본값(SeokRae-patch-1) 사용 — 리네임 UI 접근 불가, 머지 후 삭제되므로 영향 없음

## 머지 후

- v0.17.3 릴리즈 태그 필요